### PR TITLE
Ensure directory exists when saving results

### DIFF
--- a/src/reporter/HTMLReporter.ts
+++ b/src/reporter/HTMLReporter.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import * as path from 'path'
 import { ApexMutationTestResult } from '../type/ApexMutationTestResult.js'
 
@@ -7,6 +7,8 @@ export class ApexMutationHTMLReporter {
     apexMutationTestResult: ApexMutationTestResult,
     outputDir: string = 'reports'
   ): Promise<void> {
+    await mkdir(outputDir, { recursive: true })
+
     const reportData = this.transformApexResults(apexMutationTestResult)
     // Generate and write the HTML file with the report data embedded
     const htmlContent = createReportHtml(reportData)

--- a/test/integration/run.nut.ts
+++ b/test/integration/run.nut.ts
@@ -14,7 +14,7 @@ describe('apex mutation test run NUTs', () => {
 
     // Run the mutation test command
     execCmd<ApexMutationTestResult>(
-      `apex mutation test run -o bulk-wizard --apex-class Mutation --test-class MutationTest --json`,
+      `apex mutation test run -o apex-mutation-testing --apex-class Mutation --test-class MutationTest --json`,
       {
         ensureExitCode: 0,
       }
@@ -61,7 +61,7 @@ describe('apex mutation test run NUTs', () => {
 
     // Run the mutation test command
     execCmd<ApexMutationTestResult>(
-      `apex mutation test run -o bulk-wizard --report-dir ${reportDir} --apex-class Mutation --test-class MutationTest --json`,
+      `apex mutation test run -o apex-mutation-testing --report-dir ${reportDir} --apex-class Mutation --test-class MutationTest --json`,
       {
         ensureExitCode: 0,
       }

--- a/test/integration/run.nut.ts
+++ b/test/integration/run.nut.ts
@@ -1,11 +1,92 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
 import { execCmd } from '@salesforce/cli-plugins-testkit'
 import { expect } from 'chai'
 import { describe, it } from 'mocha'
 import { ApexMutationTestResult } from '../../src/commands/apex/mutation/test/run.js'
 
-//import { join } from 'node:path'
-
 describe('apex mutation test run NUTs', () => {
+  it('should create report directory and index.html by default', async () => {
+    const reportDir = 'mutations'
+
+    // Ensure the directory doesn't exist before the test
+    await fs.rm(reportDir, { recursive: true, force: true })
+
+    // Run the mutation test command
+    execCmd<ApexMutationTestResult>(
+      `apex mutation test run -o bulk-wizard --apex-class Mutation --test-class MutationTest --json`,
+      {
+        ensureExitCode: 0,
+      }
+    ).shellOutput
+
+    // Check directory exists
+    const dirExists = await fs
+      .access(reportDir)
+      .then(() => true)
+      .catch(() => false)
+    expect(dirExists, `Report directory ${reportDir} should exist`).to.be.true
+
+    // Check index.html exists in the directory
+    const indexPath = path.join(reportDir, 'index.html')
+    const indexExists = await fs
+      .access(indexPath)
+      .then(() => true)
+      .catch(() => false)
+    expect(indexExists, `Index.html should exist at ${indexPath}`).to.be.true
+
+    // Read the contents of the index.html
+    const indexContent = await fs.readFile(indexPath, 'utf-8')
+    expect(indexContent).to.include('mutation-test-report-app')
+  })
+
+  it('should display help', () => {
+    // Act
+    const result = execCmd<ApexMutationTestResult>(
+      'apex mutation test run --help',
+      {
+        ensureExitCode: 0,
+      }
+    ).shellOutput
+
+    // Assert
+    expect(result).to.include('mutation')
+  })
+
+  it('should create report directory with passed in argument', async () => {
+    const reportDir = 'reports/nut-directory-test'
+
+    // Ensure the directory doesn't exist before the test
+    await fs.rm(reportDir, { recursive: true, force: true })
+
+    // Run the mutation test command
+    execCmd<ApexMutationTestResult>(
+      `apex mutation test run -o bulk-wizard --report-dir ${reportDir} --apex-class Mutation --test-class MutationTest --json`,
+      {
+        ensureExitCode: 0,
+      }
+    ).shellOutput
+
+    // Check directory exists
+    const dirExists = await fs
+      .access(reportDir)
+      .then(() => true)
+      .catch(() => false)
+    expect(dirExists, `Report directory ${reportDir} should exist`).to.be.true
+
+    // Check index.html exists in the directory
+    const indexPath = path.join(reportDir, 'index.html')
+    const indexExists = await fs
+      .access(indexPath)
+      .then(() => true)
+      .catch(() => false)
+    expect(indexExists, `Index.html should exist at ${indexPath}`).to.be.true
+
+    // Optional: Read the contents of the index.html
+    const indexContent = await fs.readFile(indexPath, 'utf-8')
+    expect(indexContent).to.include('mutation-test-report-app')
+  })
+
   it('should display help', () => {
     // Act
     const result = execCmd<ApexMutationTestResult>(


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes
When I run the command (`sf apex mutation test run -c myClass --test-class TestMyClass`) currently, it fails with

> Error (ENOENT): ENOENT: no such file or directory, open 'mutations/index.html'

This is to ensure the directory exists before saving the output.
---

<!--
  Describe with your own words the content of the Pull Request
-->

Create directory, if need be, if it currently doesn't exist before saving output into it. Also, correcting the default directory name (if none provided) to `mutations` based on README
# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #

- [ ] Jest tests added to cover the fix.
- [x] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

# Any other comments

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->
