### PR TITLE
feat: add arithmetic operator + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sf plugins install apex-mutation-testing
 ```
 
 ```sh
-sf apex mutation test run --class-file MyClass --test-file MyClassTest
+sf apex mutation test run --apex-class MyClass --test-class MyClassTest
 ```
 
 ## What is it mutation testing ?
@@ -104,7 +104,7 @@ DESCRIPTION
 EXAMPLES
   Run mutation testing on a class with its test file:
 
-    $ sf apex mutation test run --class-file MyClass --test-file MyClassTest
+    $ sf apex mutation test run --apex-class MyClass --test-class MyClassTest
 ```
 <!-- commandsstop -->
 
@@ -128,6 +128,7 @@ Versioning follows [SemVer](http://semver.org/) specification.
 ## Authors
 
 - **Sebastien Colladon** - Developer - [scolladon](https://github.com/scolladon)
+- **Saman Attar** - Developer - [saman](https://github.com/SamanAttar)
 
 Special thanks to **Sara Sali** for her [presentation at Dreamforce](https://www.youtube.com/watch?v=8PjzrTaNNns) about apex mutation testing
 This repository is basically a port of her idea / repo to a sf plugin.

--- a/src/mutator/arithmeticOperatorMutator.ts
+++ b/src/mutator/arithmeticOperatorMutator.ts
@@ -1,0 +1,43 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { BaseListener } from './baseListener.js'
+
+export class ArithmeticOperatorMutator extends BaseListener {
+  private readonly REPLACEMENT_MAP: Record<string, string[]> = {
+    '+': ['-', '*', '/'],
+    '-': ['+', '*', '/'],
+    '*': ['+', '-', '/'],
+    '/': ['+', '-', '*'],
+  }
+
+  // Handle MUL, DIV, and MOD operations (*, /, %)
+  enterArth1Expression(ctx: ParserRuleContext): void {
+    this.processArithmeticOperation(ctx)
+  }
+
+  // Handle ADD and SUB operations (+, -)
+  enterArth2Expression(ctx: ParserRuleContext): void {
+    this.processArithmeticOperation(ctx)
+  }
+
+  enterAssignExpression(_ctx: ParserRuleContext): void {
+    // Method intentionally left empty - enables traversal into children
+  }
+
+  private processArithmeticOperation(ctx: ParserRuleContext): void {
+    if (ctx.childCount === 3) {
+      const operatorNode = ctx.getChild(1)
+
+      if (operatorNode instanceof TerminalNode) {
+        const operatorText = operatorNode.text
+        const replacements = this.REPLACEMENT_MAP[operatorText]
+
+        if (replacements) {
+          for (const replacement of replacements) {
+            this.createMutationFromTerminalNode(operatorNode, replacement)
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -1,3 +1,4 @@
+import { ArithmeticOperatorMutator } from '../mutator/arithmeticOperatorMutator.js'
 import { BoundaryConditionMutator } from '../mutator/boundaryConditionMutator.js'
 import { EmptyReturnMutator } from '../mutator/emptyReturnMutator.js'
 import { EqualityConditionMutator } from '../mutator/equalityConditionMutator.js'
@@ -49,6 +50,7 @@ export class MutantGenerator {
     const falseReturnListener = new FalseReturnMutator()
     const nullReturnListener = new NullReturnMutator()
     const equalityListener = new EqualityConditionMutator()
+    const arithmeticListener = new ArithmeticOperatorMutator()
 
     const listener = new MutationListener(
       [
@@ -59,6 +61,7 @@ export class MutantGenerator {
         trueReturnListener,
         falseReturnListener,
         nullReturnListener,
+        arithmeticListener,
       ],
       coveredLines,
       methodTypeTable

--- a/test/unit/mutator/arithmeticOperatorMutator.test.ts
+++ b/test/unit/mutator/arithmeticOperatorMutator.test.ts
@@ -1,0 +1,266 @@
+import { ParserRuleContext, Token } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { ArithmeticOperatorMutator } from '../../../src/mutator/arithmeticOperatorMutator.js'
+
+describe('ArithmeticOperatorMutator', () => {
+  let sut: ArithmeticOperatorMutator
+  let mockCtx: ParserRuleContext
+  let mockTerminalNode: TerminalNode
+
+  beforeEach(() => {
+    // Arrange
+    sut = new ArithmeticOperatorMutator()
+    mockCtx = {
+      childCount: 3,
+      getChild: jest.fn().mockImplementation(index => {
+        return index === 1 ? mockTerminalNode : {}
+      }),
+    } as unknown as ParserRuleContext
+    mockTerminalNode = {
+      text: '+',
+    } as unknown as TerminalNode
+  })
+
+  it('should mutate addition operator', () => {
+    // Arrange
+    mockTerminalNode = new TerminalNode({ text: '+' } as Token)
+
+    // Act
+    sut.enterArth2Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(3)
+    expect(sut['_mutations'][0].replacement).toBe('-')
+    expect(sut['_mutations'][1].replacement).toBe('*')
+    expect(sut['_mutations'][2].replacement).toBe('/')
+  })
+
+  it('should mutate subtraction operator', () => {
+    // Arrange
+    mockTerminalNode = new TerminalNode({ text: '-' } as Token)
+
+    // Act
+    sut.enterArth2Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(3)
+    expect(sut['_mutations'][0].replacement).toBe('+')
+    expect(sut['_mutations'][1].replacement).toBe('*')
+    expect(sut['_mutations'][2].replacement).toBe('/')
+  })
+
+  it('should mutate multiplication operator', () => {
+    // Arrange
+    mockTerminalNode = new TerminalNode({ text: '*' } as Token)
+
+    // Act
+    sut.enterArth1Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(3)
+    expect(sut['_mutations'][0].replacement).toBe('+')
+    expect(sut['_mutations'][1].replacement).toBe('-')
+    expect(sut['_mutations'][2].replacement).toBe('/')
+  })
+
+  it('should mutate division operator', () => {
+    // Arrange
+    mockTerminalNode = new TerminalNode({ text: '/' } as Token)
+
+    // Act
+    sut.enterArth1Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(3)
+    expect(sut['_mutations'][0].replacement).toBe('+')
+    expect(sut['_mutations'][1].replacement).toBe('-')
+    expect(sut['_mutations'][2].replacement).toBe('*')
+  })
+
+  it('should not mutate when child count is not 3', () => {
+    // Arrange
+    mockCtx = { childCount: 2 } as unknown as ParserRuleContext
+
+    // Act
+    sut.enterArth1Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(0)
+  })
+
+  it('should not mutate when terminal node is not found', () => {
+    // Arrange
+    mockCtx.getChild = jest.fn().mockReturnValue({})
+
+    // Act
+    sut.enterArth1Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(0)
+  })
+
+  it('should not mutate when operator is not in replacement map', () => {
+    // Arrange
+    mockTerminalNode = new TerminalNode({ text: '==' } as Token)
+
+    // Act
+    sut.enterArth1Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(0)
+  })
+
+  it('should have an enterAssignExpression method', () => {
+    // Assert
+    expect(typeof sut.enterAssignExpression).toBe('function')
+  })
+
+  it('enterAssignExpression should not directly create mutations', () => {
+    // Arrange
+    const assignCtx = {
+      childCount: 3,
+      getChild: jest.fn().mockImplementation(index => {
+        // Right side is an arithmetic expression
+        if (index === 2) {
+          return {
+            // Arth2Expression in the actual parse tree
+          }
+        }
+        return {}
+      }),
+    } as unknown as ParserRuleContext
+
+    // Act
+    sut.enterAssignExpression(assignCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(0) // No mutations directly from enterAssignExpression
+  })
+
+  it('should process arithmetic operations in assignment expressions via traversal', () => {
+    // Arrange
+    const assignCtx = {
+      childCount: 3,
+      getChild: jest.fn().mockImplementation(index => {
+        return index === 2
+          ? {
+              //visited separately by the parser
+            }
+          : {}
+      }),
+    } as unknown as ParserRuleContext
+
+    const arithmeticCtx = {
+      childCount: 3,
+      getChild: jest.fn().mockImplementation(index => {
+        return index === 1 ? mockTerminalNode : {}
+      }),
+    } as unknown as ParserRuleContext
+
+    mockTerminalNode = new TerminalNode({ text: '+' } as Token)
+
+    // Act
+    sut.enterAssignExpression(assignCtx)
+    sut.enterArth2Expression(arithmeticCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(3)
+    expect(sut['_mutations'][0].replacement).toBe('-')
+  })
+
+  it('should handle multiple operators in sequence', () => {
+    // Arrange
+    const firstArithmeticCtx = {
+      childCount: 3,
+      getChild: jest.fn().mockImplementation(index => {
+        return index === 1 ? new TerminalNode({ text: '+' } as Token) : {}
+      }),
+    } as unknown as ParserRuleContext
+
+    const secondArithmeticCtx = {
+      childCount: 3,
+      getChild: jest.fn().mockImplementation(index => {
+        return index === 1 ? new TerminalNode({ text: '*' } as Token) : {}
+      }),
+    } as unknown as ParserRuleContext
+
+    // Act
+    sut.enterArth2Expression(firstArithmeticCtx)
+    sut.enterArth1Expression(secondArithmeticCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(6)
+
+    // for +
+    expect(sut['_mutations'][0].replacement).toBe('-')
+    expect(sut['_mutations'][1].replacement).toBe('*')
+    expect(sut['_mutations'][2].replacement).toBe('/')
+
+    // for *
+    expect(sut['_mutations'][3].replacement).toBe('+')
+    expect(sut['_mutations'][4].replacement).toBe('-')
+    expect(sut['_mutations'][5].replacement).toBe('/')
+  })
+
+  it('should create mutations with correct mutator name', () => {
+    // Arrange
+    mockTerminalNode = new TerminalNode({ text: '+' } as Token)
+
+    // Act
+    sut.enterArth2Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(3)
+    sut['_mutations'].forEach(mutation => {
+      expect(mutation.mutationName).toBe('ArithmeticOperatorMutator')
+    })
+  })
+
+  it('should not mutate non-arithmetic operators', () => {
+    // Arrange
+    const nonArithmeticOperators = [
+      '==',
+      '!=',
+      '&&',
+      '||',
+      '>',
+      '<',
+      '>=',
+      '<=',
+    ]
+
+    nonArithmeticOperators.forEach(operator => {
+      sut = new ArithmeticOperatorMutator()
+      mockTerminalNode = new TerminalNode({ text: operator } as Token)
+
+      // Act
+      sut.enterArth1Expression(mockCtx)
+      sut.enterArth2Expression(mockCtx)
+
+      // Assert
+      expect(sut['_mutations']).toHaveLength(0)
+    })
+  })
+
+  it('should handle edge case with null terminal node text', () => {
+    // Arrange
+    mockTerminalNode = new TerminalNode({ text: null } as unknown as Token)
+
+    // Act
+    sut.enterArth1Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(0)
+  })
+
+  it('should handle edge case with undefined terminal node text', () => {
+    // Arrange
+    mockTerminalNode = new TerminalNode({ text: undefined } as unknown as Token)
+
+    // Act
+    sut.enterArth1Expression(mockCtx)
+
+    // Assert
+    expect(sut['_mutations']).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

Copied from PR https://github.com/scolladon/apex-mutation-testing/pull/47

# Explain your changes
- Creating an Arithmetic Operator Replacement Mutator modeled after [PIT's AOR ](https://pitest.org/quickstart/mutators/#:~:text=Arithmetic%20Operator%20Replacement%20Mutator%20(AOR))
- Introducing ```enterArth1Expression``` listener to capture ```*``` and ```/```
- Introducing ```enterArth2Expression``` listener to capture ```+``` and ```-```
- Introduced ```enterAssignExpression``` listener to ensure parser continues walking the tree properly to find arithmetic operations inside assignments
---



# Does this close any currently open issues?

  Closes: [#22](https://github.com/scolladon/apex-mutation-testing/issues/22)
---


- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.


---



# Any other comments
