### PR TITLE
feat: add Logical Operator Mutator

### DIFF
--- a/src/mutator/logicalOperatorMutator.ts
+++ b/src/mutator/logicalOperatorMutator.ts
@@ -1,0 +1,35 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { BaseListener } from './baseListener.js'
+
+export class LogicalOperatorMutator extends BaseListener {
+  private readonly REPLACEMENT_MAP: Record<string, string> = {
+    '&&': '||',
+    '||': '&&',
+  }
+
+  // Handle && (logical AND) expressions
+  enterLogAndExpression(ctx: ParserRuleContext): void {
+    this.processLogicalOperation(ctx)
+  }
+
+  // Handle || (logical OR) expressions
+  enterLogOrExpression(ctx: ParserRuleContext): void {
+    this.processLogicalOperation(ctx)
+  }
+
+  private processLogicalOperation(ctx: ParserRuleContext): void {
+    if (ctx.childCount === 3) {
+      const operatorNode = ctx.getChild(1)
+
+      if (operatorNode instanceof TerminalNode) {
+        const operatorText = operatorNode.text
+        const replacement = this.REPLACEMENT_MAP[operatorText]
+
+        if (replacement) {
+          this.createMutationFromTerminalNode(operatorNode, replacement)
+        }
+      }
+    }
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -13,6 +13,7 @@ import { EmptyReturnMutator } from '../mutator/emptyReturnMutator.js'
 import { EqualityConditionMutator } from '../mutator/equalityConditionMutator.js'
 import { FalseReturnMutator } from '../mutator/falseReturnMutator.js'
 import { IncrementMutator } from '../mutator/incrementMutator.js'
+import { LogicalOperatorMutator } from '../mutator/logicalOperatorMutator.js'
 import { MutationListener } from '../mutator/mutationListener.js'
 import { NullReturnMutator } from '../mutator/nullReturnMutator.js'
 import { TrueReturnMutator } from '../mutator/trueReturnMutator.js'
@@ -48,6 +49,7 @@ export class MutantGenerator {
     const nullReturnListener = new NullReturnMutator()
     const equalityListener = new EqualityConditionMutator()
     const arithmeticListener = new ArithmeticOperatorMutator()
+    const logicalOperatorListener = new LogicalOperatorMutator()
 
     const listener = new MutationListener(
       [
@@ -59,6 +61,7 @@ export class MutantGenerator {
         falseReturnListener,
         nullReturnListener,
         arithmeticListener,
+        logicalOperatorListener,
       ],
       coveredLines,
       methodTypeTable

--- a/test/integration/logicalOperatorMutator.integration.test.ts
+++ b/test/integration/logicalOperatorMutator.integration.test.ts
@@ -1,0 +1,117 @@
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { LogicalOperatorMutator } from '../../src/mutator/logicalOperatorMutator.js'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+
+describe('LogicalOperatorMutator Integration', () => {
+  const parseAndMutate = (code: string, coveredLines: Set<number>) => {
+    const lexer = new ApexLexer(new CaseInsensitiveInputStream('test', code))
+    const tokenStream = new CommonTokenStream(lexer)
+    const parser = new ApexParser(tokenStream)
+    const tree = parser.compilationUnit()
+
+    const logicalOperatorMutator = new LogicalOperatorMutator()
+    const listener = new MutationListener(
+      [logicalOperatorMutator],
+      coveredLines
+    )
+
+    ParseTreeWalker.DEFAULT.walk(listener as ApexParserListener, tree)
+    return listener.getMutations()
+  }
+
+  describe('Given Apex code with && operator', () => {
+    it('Then should generate mutation replacing && with ||', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            if (a && b) {
+              doSomething();
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('||')
+      expect(mutations[0].mutationName).toBe('LogicalOperatorMutator')
+    })
+  })
+
+  describe('Given Apex code with || operator', () => {
+    it('Then should generate mutation replacing || with &&', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            if (x || y) {
+              doSomething();
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('&&')
+      expect(mutations[0].mutationName).toBe('LogicalOperatorMutator')
+    })
+  })
+
+  describe('Given Apex code with nested logical operators', () => {
+    it('Then should generate mutations for each operator', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Boolean result = (a && b) || (c && d);
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      // Should find 3 operators: && (twice) and || (once)
+      expect(mutations.length).toBe(3)
+      expect(mutations.filter(m => m.replacement === '||').length).toBe(2)
+      expect(mutations.filter(m => m.replacement === '&&').length).toBe(1)
+    })
+  })
+
+  describe('Given Apex code with logical operators on uncovered lines', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            if (a && b) {
+              doSomething();
+            }
+          }
+        }
+      `
+
+      // Act - line 4 is not covered
+      const mutations = parseAndMutate(code, new Set([5]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+})

--- a/test/unit/mutator/logicalOperatorMutator.test.ts
+++ b/test/unit/mutator/logicalOperatorMutator.test.ts
@@ -1,0 +1,89 @@
+import { ParserRuleContext, Token } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { LogicalOperatorMutator } from '../../../src/mutator/logicalOperatorMutator.js'
+
+describe('LogicalOperatorMutator', () => {
+  let sut: LogicalOperatorMutator
+  let mockCtx: ParserRuleContext
+  let mockTerminalNode: TerminalNode
+
+  beforeEach(() => {
+    sut = new LogicalOperatorMutator()
+    mockCtx = {
+      childCount: 3,
+      getChild: jest.fn().mockImplementation(index => {
+        return index === 1 ? mockTerminalNode : {}
+      }),
+    } as unknown as ParserRuleContext
+  })
+
+  describe('Given a LogAndExpression (&&)', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation to replace && with ||', () => {
+        // Arrange
+        mockTerminalNode = new TerminalNode({ text: '&&' } as Token)
+
+        // Act
+        sut.enterLogAndExpression(mockCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('||')
+        expect(sut._mutations[0].mutationName).toBe('LogicalOperatorMutator')
+      })
+    })
+  })
+
+  describe('Given a LogOrExpression (||)', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation to replace || with &&', () => {
+        // Arrange
+        mockTerminalNode = new TerminalNode({ text: '||' } as Token)
+
+        // Act
+        sut.enterLogOrExpression(mockCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('&&')
+        expect(sut._mutations[0].mutationName).toBe('LogicalOperatorMutator')
+      })
+    })
+  })
+
+  describe('Given an expression with insufficient children', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 2, // Not enough children
+          getChild: () => ({}),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterLogAndExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given an expression where child is not a TerminalNode', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 3,
+          getChild: () => ({}), // Not a TerminalNode
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterLogAndExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Explain your changes

---

Adds a new mutation operator that swaps logical operators:
- `&&` → `||`
- `||` → `&&`

This helps detect weaknesses in tests that don't properly verify complex boolean logic in conditional statements. For example, if a test passes with both `if (a && b)` and `if (a || b)`, it indicates insufficient test coverage of the boolean condition.

# Does this close any currently open issues?

---

closes #36

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

Run mutation testing on an Apex class containing `&&` or `||` operators. The new mutator will generate mutations swapping these operators.

# Any other comments

---

This is the first mutator in the v1.3 release (all mutators). The implementation follows the established patterns from existing mutators like `ArithmeticOperatorMutator`.