### PR TITLE
feat: add invert negatives mutator

### DIFF
--- a/src/mutator/invertNegativesMutator.ts
+++ b/src/mutator/invertNegativesMutator.ts
@@ -1,0 +1,29 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { BaseListener } from './baseListener.js'
+
+export class InvertNegativesMutator extends BaseListener {
+  // Handle unary minus expressions: -x, -5, etc.
+  // PreOpExpression has structure: [operator, expression]
+  enterPreOpExpression(ctx: ParserRuleContext): void {
+    if (ctx.childCount !== 2) {
+      return
+    }
+
+    const operatorNode = ctx.getChild(0)
+
+    if (!(operatorNode instanceof TerminalNode)) {
+      return
+    }
+
+    // Only handle unary minus, not ++ or --
+    if (operatorNode.text !== '-') {
+      return
+    }
+
+    const innerExpression = ctx.getChild(1) as ParserRuleContext
+
+    // Replace -x with x (remove the negation)
+    this.createMutationFromParserRuleContext(ctx, innerExpression.text)
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -13,6 +13,7 @@ import { EmptyReturnMutator } from '../mutator/emptyReturnMutator.js'
 import { EqualityConditionMutator } from '../mutator/equalityConditionMutator.js'
 import { FalseReturnMutator } from '../mutator/falseReturnMutator.js'
 import { IncrementMutator } from '../mutator/incrementMutator.js'
+import { InvertNegativesMutator } from '../mutator/invertNegativesMutator.js'
 import { LogicalOperatorMutator } from '../mutator/logicalOperatorMutator.js'
 import { MutationListener } from '../mutator/mutationListener.js'
 import { NullReturnMutator } from '../mutator/nullReturnMutator.js'
@@ -49,6 +50,7 @@ export class MutantGenerator {
     const nullReturnListener = new NullReturnMutator()
     const equalityListener = new EqualityConditionMutator()
     const arithmeticListener = new ArithmeticOperatorMutator()
+    const invertNegativesListener = new InvertNegativesMutator()
     const logicalOperatorListener = new LogicalOperatorMutator()
 
     const listener = new MutationListener(
@@ -61,6 +63,7 @@ export class MutantGenerator {
         falseReturnListener,
         nullReturnListener,
         arithmeticListener,
+        invertNegativesListener,
         logicalOperatorListener,
       ],
       coveredLines,

--- a/test/integration/invertNegativesMutator.integration.test.ts
+++ b/test/integration/invertNegativesMutator.integration.test.ts
@@ -1,0 +1,150 @@
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { InvertNegativesMutator } from '../../src/mutator/invertNegativesMutator.js'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+
+describe('InvertNegativesMutator Integration', () => {
+  const parseAndMutate = (code: string, coveredLines: Set<number>) => {
+    const lexer = new ApexLexer(new CaseInsensitiveInputStream('test', code))
+    const tokenStream = new CommonTokenStream(lexer)
+    const parser = new ApexParser(tokenStream)
+    const tree = parser.compilationUnit()
+
+    const invertNegativesMutator = new InvertNegativesMutator()
+    const listener = new MutationListener(
+      [invertNegativesMutator],
+      coveredLines
+    )
+
+    ParseTreeWalker.DEFAULT.walk(listener as ApexParserListener, tree)
+    return listener.getMutations()
+  }
+
+  describe('Given Apex code with negated variable', () => {
+    it('Then should generate mutation removing the negation', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Integer result = -x;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('x')
+      expect(mutations[0].mutationName).toBe('InvertNegativesMutator')
+    })
+  })
+
+  describe('Given Apex code with negated literal', () => {
+    it('Then should generate mutation removing the negation', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Integer result = -5;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('5')
+    })
+  })
+
+  describe('Given Apex code with negated expression', () => {
+    it('Then should generate mutation removing the negation', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Integer result = -(a + b);
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('(a+b)')
+    })
+  })
+
+  describe('Given Apex code with multiple negations', () => {
+    it('Then should generate mutations for each negation', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Integer a = -x;
+            Integer b = -y;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4, 5]))
+
+      // Assert
+      expect(mutations.length).toBe(2)
+      expect(mutations[0].replacement).toBe('x')
+      expect(mutations[1].replacement).toBe('y')
+    })
+  })
+
+  describe('Given Apex code with increment/decrement (not negation)', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            ++i;
+            --j;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4, 5]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with negation on uncovered lines', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Integer result = -x;
+          }
+        }
+      `
+
+      // Act - line 4 is not covered
+      const mutations = parseAndMutate(code, new Set([5]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+})

--- a/test/unit/mutator/invertNegativesMutator.test.ts
+++ b/test/unit/mutator/invertNegativesMutator.test.ts
@@ -1,0 +1,181 @@
+import { ParserRuleContext, Token } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { InvertNegativesMutator } from '../../../src/mutator/invertNegativesMutator.js'
+
+describe('InvertNegativesMutator', () => {
+  let sut: InvertNegativesMutator
+
+  beforeEach(() => {
+    sut = new InvertNegativesMutator()
+  })
+
+  describe('Given a PreOpExpression with unary minus on variable', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation to remove the negation', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const operatorNode = new TerminalNode({ text: '-' } as Token)
+
+        const innerExpression = {
+          text: 'x',
+          start: { tokenIndex: 6 } as Token,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? operatorNode : innerExpression
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: '-x',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('x')
+        expect(sut._mutations[0].mutationName).toBe('InvertNegativesMutator')
+      })
+    })
+  })
+
+  describe('Given a PreOpExpression with unary minus on number', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation to remove the negation', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const operatorNode = new TerminalNode({ text: '-' } as Token)
+
+        const innerExpression = {
+          text: '5',
+          start: { tokenIndex: 6 } as Token,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? operatorNode : innerExpression
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: '-5',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('5')
+        expect(sut._mutations[0].mutationName).toBe('InvertNegativesMutator')
+      })
+    })
+  })
+
+  describe('Given a PreOpExpression with increment operator (++)', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const operatorNode = new TerminalNode({ text: '++' } as Token)
+
+        const innerExpression = {
+          text: 'i',
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? operatorNode : innerExpression
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a PreOpExpression with decrement operator (--)', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const operatorNode = new TerminalNode({ text: '--' } as Token)
+
+        const innerExpression = {
+          text: 'i',
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? operatorNode : innerExpression
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given an expression with wrong number of children', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 3,
+          getChild: () => ({}),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given an expression where first child is not a TerminalNode', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 2,
+          getChild: () => ({}), // Not a TerminalNode
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Explain your changes

Implements the InvertNegativesMutator that transforms unary minus expressions (`-x`) into their positive form (`x`). This mutator helps detect code that may not properly handle sign changes in numeric expressions.

The implementation:
- Extends `BaseListener` and hooks into `enterPreOpExpression`
- Detects unary minus operator (`-`) and generates mutation to remove the negation
- Correctly ignores `++` and `--` operators

# Does this close any currently open issues?

closes #31

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

Run the mutation testing against Apex code containing negated expressions:
- `-x` → `x`
- `-5` → `5`
- `-(a + b)` → `(a+b)`

# Any other comments

Part of v1.3 mutator implementation series.