### PR TITLE
feat: add negation mutator

### DIFF
--- a/src/mutator/negationMutator.ts
+++ b/src/mutator/negationMutator.ts
@@ -1,0 +1,51 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { BaseListener } from './baseListener.js'
+
+export class NegationMutator extends BaseListener {
+  // Values that should not be negated
+  private readonly EXCLUDED_VALUES = new Set(['true', 'false', 'null'])
+
+  // Handle return statements: return x; -> return -x;
+  enterReturnStatement(ctx: ParserRuleContext): void {
+    // Get the expression from the return statement
+    const expression = (ctx as ReturnStatementContext).expression?.()
+
+    if (!expression) {
+      return
+    }
+
+    const expressionText = expression.text
+
+    // Skip if already negated
+    if (expressionText.startsWith('-')) {
+      return
+    }
+
+    // Skip non-numeric values (strings, booleans, null)
+    if (this.shouldSkipExpression(expressionText)) {
+      return
+    }
+
+    // Create mutation: x -> -x
+    this.createMutationFromParserRuleContext(expression, `-${expressionText}`)
+  }
+
+  private shouldSkipExpression(text: string): boolean {
+    // Skip excluded values (true, false, null)
+    if (this.EXCLUDED_VALUES.has(text.toLowerCase())) {
+      return true
+    }
+
+    // Skip string literals
+    if (text.startsWith("'") || text.startsWith('"')) {
+      return true
+    }
+
+    return false
+  }
+}
+
+// Type helper for ReturnStatement context
+interface ReturnStatementContext extends ParserRuleContext {
+  expression(): ParserRuleContext | null
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -16,6 +16,7 @@ import { IncrementMutator } from '../mutator/incrementMutator.js'
 import { InvertNegativesMutator } from '../mutator/invertNegativesMutator.js'
 import { LogicalOperatorMutator } from '../mutator/logicalOperatorMutator.js'
 import { MutationListener } from '../mutator/mutationListener.js'
+import { NegationMutator } from '../mutator/negationMutator.js'
 import { NullReturnMutator } from '../mutator/nullReturnMutator.js'
 import { TrueReturnMutator } from '../mutator/trueReturnMutator.js'
 import { ApexMutation } from '../type/ApexMutation.js'
@@ -52,6 +53,7 @@ export class MutantGenerator {
     const arithmeticListener = new ArithmeticOperatorMutator()
     const invertNegativesListener = new InvertNegativesMutator()
     const logicalOperatorListener = new LogicalOperatorMutator()
+    const negationListener = new NegationMutator()
 
     const listener = new MutationListener(
       [
@@ -65,6 +67,7 @@ export class MutantGenerator {
         arithmeticListener,
         invertNegativesListener,
         logicalOperatorListener,
+        negationListener,
       ],
       coveredLines,
       methodTypeTable

--- a/test/integration/negationMutator.integration.test.ts
+++ b/test/integration/negationMutator.integration.test.ts
@@ -1,0 +1,241 @@
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+import { NegationMutator } from '../../src/mutator/negationMutator.js'
+
+describe('NegationMutator Integration', () => {
+  const parseAndMutate = (code: string, coveredLines: Set<number>) => {
+    const lexer = new ApexLexer(new CaseInsensitiveInputStream('test', code))
+    const tokenStream = new CommonTokenStream(lexer)
+    const parser = new ApexParser(tokenStream)
+    const tree = parser.compilationUnit()
+
+    const negationMutator = new NegationMutator()
+    const listener = new MutationListener([negationMutator], coveredLines)
+
+    ParseTreeWalker.DEFAULT.walk(listener as ApexParserListener, tree)
+    return listener.getMutations()
+  }
+
+  describe('Given Apex code with return statement returning variable', () => {
+    it('Then should generate mutation to negate the variable', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Integer test() {
+            return x;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('-x')
+      expect(mutations[0].mutationName).toBe('NegationMutator')
+    })
+  })
+
+  describe('Given Apex code with return statement returning numeric literal', () => {
+    it('Then should generate mutation to negate the literal', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Integer test() {
+            return 42;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('-42')
+    })
+  })
+
+  describe('Given Apex code with return statement already negated', () => {
+    it('Then should not generate mutation', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Integer test() {
+            return -x;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with multiple return statements', () => {
+    it('Then should generate mutations for each eligible return', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Integer test(Boolean condition) {
+            if (condition) {
+              return x;
+            }
+            return y;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([5, 7]))
+
+      // Assert
+      expect(mutations.length).toBe(2)
+      expect(mutations[0].replacement).toBe('-x')
+      expect(mutations[1].replacement).toBe('-y')
+    })
+  })
+
+  describe('Given Apex code with return statement returning boolean', () => {
+    it('Then should not generate mutation for true', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Boolean test() {
+            return true;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+
+    it('Then should not generate mutation for false', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Boolean test() {
+            return false;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with return statement returning null', () => {
+    it('Then should not generate mutation', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Object test() {
+            return null;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with return statement returning string', () => {
+    it('Then should not generate mutation', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public String test() {
+            return 'hello';
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with void return', () => {
+    it('Then should not generate mutation', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            return;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with return on uncovered lines', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Integer test() {
+            return x;
+          }
+        }
+      `
+
+      // Act - line 4 is not covered
+      const mutations = parseAndMutate(code, new Set([5]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with return statement returning expression', () => {
+    it('Then should generate mutation to negate the expression', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Integer test() {
+            return a + b;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('-a+b')
+    })
+  })
+})

--- a/test/unit/mutator/negationMutator.test.ts
+++ b/test/unit/mutator/negationMutator.test.ts
@@ -1,0 +1,301 @@
+import { ParserRuleContext, Token } from 'antlr4ts'
+import { NegationMutator } from '../../../src/mutator/negationMutator.js'
+
+describe('NegationMutator', () => {
+  let sut: NegationMutator
+
+  beforeEach(() => {
+    sut = new NegationMutator()
+  })
+
+  describe('Given a return statement with a variable', () => {
+    describe('When entering the statement', () => {
+      it('Then should create mutation to negate the value', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const expressionCtx = {
+          text: 'x',
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3, // 'return', expression, ';'
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 1) return expressionCtx
+            return { text: index === 0 ? 'return' : ';' }
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 7 } as Token,
+          text: 'return x;',
+          expression: jest.fn().mockReturnValue(expressionCtx),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterReturnStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('-x')
+        expect(sut._mutations[0].mutationName).toBe('NegationMutator')
+      })
+    })
+  })
+
+  describe('Given a return statement with a numeric literal', () => {
+    describe('When entering the statement', () => {
+      it('Then should create mutation to negate the value', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const expressionCtx = {
+          text: '5',
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 1) return expressionCtx
+            return { text: index === 0 ? 'return' : ';' }
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 7 } as Token,
+          text: 'return 5;',
+          expression: jest.fn().mockReturnValue(expressionCtx),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterReturnStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('-5')
+      })
+    })
+  })
+
+  describe('Given a return statement that already has negation', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create mutation (avoid double negation)', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const expressionCtx = {
+          text: '-x',
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 1) return expressionCtx
+            return { text: index === 0 ? 'return' : ';' }
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 7 } as Token,
+          text: 'return -x;',
+          expression: jest.fn().mockReturnValue(expressionCtx),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterReturnStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given an empty return statement', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 2, // 'return', ';'
+          getChild: jest.fn(),
+          expression: jest.fn().mockReturnValue(null),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterReturnStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement with a string literal', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create mutation', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const expressionCtx = {
+          text: "'hello'",
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 1) return expressionCtx
+            return { text: index === 0 ? 'return' : ';' }
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 7 } as Token,
+          text: "return 'hello';",
+          expression: jest.fn().mockReturnValue(expressionCtx),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterReturnStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement with a boolean', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create mutation for true', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const expressionCtx = {
+          text: 'true',
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 1) return expressionCtx
+            return { text: index === 0 ? 'return' : ';' }
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 7 } as Token,
+          text: 'return true;',
+          expression: jest.fn().mockReturnValue(expressionCtx),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterReturnStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+
+      it('Then should not create mutation for false', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const expressionCtx = {
+          text: 'false',
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 1) return expressionCtx
+            return { text: index === 0 ? 'return' : ';' }
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 7 } as Token,
+          text: 'return false;',
+          expression: jest.fn().mockReturnValue(expressionCtx),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterReturnStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement with null', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create mutation', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const expressionCtx = {
+          text: 'null',
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 1) return expressionCtx
+            return { text: index === 0 ? 'return' : ';' }
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 7 } as Token,
+          text: 'return null;',
+          expression: jest.fn().mockReturnValue(expressionCtx),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterReturnStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Explain your changes

Implements the NegationMutator that transforms return statements by negating the returned value (`x` → `-x`). This mutator helps detect code that may not properly handle sign changes in numeric return values.

The implementation:
- Extends `BaseListener` and hooks into `enterReturnStatement`
- Negates return expressions that could reasonably be numeric
- Skips already negated values (to avoid double negation)
- Skips non-numeric types: strings, booleans, and null

# Does this close any currently open issues?

closes #29

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

Run the mutation testing against Apex code containing return statements:
- `return x;` → `return -x;`
- `return 42;` → `return -42;`
- `return a + b;` → `return -a+b;`

# Any other comments

Part of v1.3 mutator implementation series.