### PR TITLE
feat: add remove increments mutator

### DIFF
--- a/src/mutator/removeIncrementsMutator.ts
+++ b/src/mutator/removeIncrementsMutator.ts
@@ -1,0 +1,54 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { BaseListener } from './baseListener.js'
+
+export class RemoveIncrementsMutator extends BaseListener {
+  // Operators to remove
+  private readonly INCREMENT_OPERATORS = new Set(['++', '--'])
+
+  // Handle post-increment/decrement: i++ -> i, i-- -> i
+  enterPostOpExpression(ctx: ParserRuleContext): void {
+    if (ctx.childCount !== 2) {
+      return
+    }
+
+    const operatorNode = ctx.getChild(1)
+
+    if (!(operatorNode instanceof TerminalNode)) {
+      return
+    }
+
+    if (!this.INCREMENT_OPERATORS.has(operatorNode.text)) {
+      return
+    }
+
+    // Get the inner expression (the variable)
+    const innerExpression = ctx.getChild(0) as ParserRuleContext
+
+    // Replace i++ with i
+    this.createMutationFromParserRuleContext(ctx, innerExpression.text)
+  }
+
+  // Handle pre-increment/decrement: ++i -> i, --i -> i
+  enterPreOpExpression(ctx: ParserRuleContext): void {
+    if (ctx.childCount !== 2) {
+      return
+    }
+
+    const operatorNode = ctx.getChild(0)
+
+    if (!(operatorNode instanceof TerminalNode)) {
+      return
+    }
+
+    if (!this.INCREMENT_OPERATORS.has(operatorNode.text)) {
+      return
+    }
+
+    // Get the inner expression (the variable)
+    const innerExpression = ctx.getChild(1) as ParserRuleContext
+
+    // Replace ++i with i
+    this.createMutationFromParserRuleContext(ctx, innerExpression.text)
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -18,6 +18,7 @@ import { LogicalOperatorMutator } from '../mutator/logicalOperatorMutator.js'
 import { MutationListener } from '../mutator/mutationListener.js'
 import { NegationMutator } from '../mutator/negationMutator.js'
 import { NullReturnMutator } from '../mutator/nullReturnMutator.js'
+import { RemoveIncrementsMutator } from '../mutator/removeIncrementsMutator.js'
 import { TrueReturnMutator } from '../mutator/trueReturnMutator.js'
 import { ApexMutation } from '../type/ApexMutation.js'
 import { ApexTypeResolver } from './apexTypeResolver.js'
@@ -54,6 +55,7 @@ export class MutantGenerator {
     const invertNegativesListener = new InvertNegativesMutator()
     const logicalOperatorListener = new LogicalOperatorMutator()
     const negationListener = new NegationMutator()
+    const removeIncrementsListener = new RemoveIncrementsMutator()
 
     const listener = new MutationListener(
       [
@@ -68,6 +70,7 @@ export class MutantGenerator {
         invertNegativesListener,
         logicalOperatorListener,
         negationListener,
+        removeIncrementsListener,
       ],
       coveredLines,
       methodTypeTable

--- a/test/integration/removeIncrementsMutator.integration.test.ts
+++ b/test/integration/removeIncrementsMutator.integration.test.ts
@@ -1,0 +1,215 @@
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+import { RemoveIncrementsMutator } from '../../src/mutator/removeIncrementsMutator.js'
+
+describe('RemoveIncrementsMutator Integration', () => {
+  const parseAndMutate = (code: string, coveredLines: Set<number>) => {
+    const lexer = new ApexLexer(new CaseInsensitiveInputStream('test', code))
+    const tokenStream = new CommonTokenStream(lexer)
+    const parser = new ApexParser(tokenStream)
+    const tree = parser.compilationUnit()
+
+    const removeIncrementsMutator = new RemoveIncrementsMutator()
+    const listener = new MutationListener(
+      [removeIncrementsMutator],
+      coveredLines
+    )
+
+    ParseTreeWalker.DEFAULT.walk(listener as ApexParserListener, tree)
+    return listener.getMutations()
+  }
+
+  describe('Given Apex code with post-increment', () => {
+    it('Then should generate mutation removing the increment', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            i++;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('i')
+      expect(mutations[0].mutationName).toBe('RemoveIncrementsMutator')
+    })
+  })
+
+  describe('Given Apex code with post-decrement', () => {
+    it('Then should generate mutation removing the decrement', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            j--;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('j')
+    })
+  })
+
+  describe('Given Apex code with pre-increment', () => {
+    it('Then should generate mutation removing the increment', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            ++i;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('i')
+    })
+  })
+
+  describe('Given Apex code with pre-decrement', () => {
+    it('Then should generate mutation removing the decrement', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            --j;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('j')
+    })
+  })
+
+  describe('Given Apex code with multiple increment operations', () => {
+    it('Then should generate mutations for each operation', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            i++;
+            j--;
+            ++k;
+            --m;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4, 5, 6, 7]))
+
+      // Assert
+      expect(mutations.length).toBe(4)
+      expect(mutations[0].replacement).toBe('i')
+      expect(mutations[1].replacement).toBe('j')
+      expect(mutations[2].replacement).toBe('k')
+      expect(mutations[3].replacement).toBe('m')
+    })
+  })
+
+  describe('Given Apex code with increment in for loop', () => {
+    it('Then should generate mutation for the increment', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            for (Integer i = 0; i < 10; i++) {
+              System.debug(i);
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('i')
+    })
+  })
+
+  describe('Given Apex code with unary minus (not increment)', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Integer x = -5;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with increment on uncovered lines', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            i++;
+          }
+        }
+      `
+
+      // Act - line 4 is not covered
+      const mutations = parseAndMutate(code, new Set([5]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with increment in expression', () => {
+    it('Then should generate mutation for increment used in assignment', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Integer x = i++;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('i')
+    })
+  })
+})

--- a/test/unit/mutator/removeIncrementsMutator.test.ts
+++ b/test/unit/mutator/removeIncrementsMutator.test.ts
@@ -1,0 +1,282 @@
+import { ParserRuleContext, Token } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { RemoveIncrementsMutator } from '../../../src/mutator/removeIncrementsMutator.js'
+
+describe('RemoveIncrementsMutator', () => {
+  let sut: RemoveIncrementsMutator
+
+  beforeEach(() => {
+    sut = new RemoveIncrementsMutator()
+  })
+
+  describe('Given a PostOpExpression with post-increment (i++)', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation removing the increment', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const innerExpression = {
+          text: 'i',
+          start: mockToken,
+          stop: { tokenIndex: 5 } as Token,
+        } as unknown as ParserRuleContext
+
+        const operatorNode = new TerminalNode({ text: '++' } as Token)
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? innerExpression : operatorNode
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: 'i++',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPostOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('i')
+        expect(sut._mutations[0].mutationName).toBe('RemoveIncrementsMutator')
+      })
+    })
+  })
+
+  describe('Given a PostOpExpression with post-decrement (i--)', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation removing the decrement', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const innerExpression = {
+          text: 'j',
+          start: mockToken,
+          stop: { tokenIndex: 5 } as Token,
+        } as unknown as ParserRuleContext
+
+        const operatorNode = new TerminalNode({ text: '--' } as Token)
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? innerExpression : operatorNode
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: 'j--',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPostOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('j')
+      })
+    })
+  })
+
+  describe('Given a PreOpExpression with pre-increment (++i)', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation removing the increment', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const operatorNode = new TerminalNode({ text: '++' } as Token)
+
+        const innerExpression = {
+          text: 'i',
+          start: { tokenIndex: 6 } as Token,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? operatorNode : innerExpression
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: '++i',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('i')
+      })
+    })
+  })
+
+  describe('Given a PreOpExpression with pre-decrement (--i)', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation removing the decrement', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 10,
+        } as Token
+
+        const operatorNode = new TerminalNode({ text: '--' } as Token)
+
+        const innerExpression = {
+          text: 'j',
+          start: { tokenIndex: 6 } as Token,
+          stop: { tokenIndex: 6 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? operatorNode : innerExpression
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: '--j',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('j')
+      })
+    })
+  })
+
+  describe('Given a PreOpExpression with unary minus (-x)', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const operatorNode = new TerminalNode({ text: '-' } as Token)
+
+        const innerExpression = {
+          text: 'x',
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? operatorNode : innerExpression
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a PreOpExpression with unary plus (+x)', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const operatorNode = new TerminalNode({ text: '+' } as Token)
+
+        const innerExpression = {
+          text: 'x',
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? operatorNode : innerExpression
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given an expression with wrong number of children', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 3,
+          getChild: () => ({}),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPostOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a PostOpExpression where operator is not a TerminalNode', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? { text: 'i' } : { text: '++' } // Not a TerminalNode
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPostOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a PreOpExpression where operator is not a TerminalNode', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? { text: '++' } : { text: 'i' } // Not a TerminalNode
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterPreOpExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+})

--- a/test/unit/service/mutantGenerator.test.ts
+++ b/test/unit/service/mutantGenerator.test.ts
@@ -64,8 +64,8 @@ describe('MutantGenerator', () => {
       // Act
       const result = sut.compute(classContent, coveredLines)
 
-      // Assert
-      expect(result).toHaveLength(2) // Both < and ++ should be found
+      // Assert - at least 3 mutations: < -> <=, ++ -> --, ++i -> i
+      expect(result.length).toBeGreaterThanOrEqual(3)
 
       const incrementMutation = result.find(
         m => m.mutationName === 'IncrementMutator'
@@ -73,12 +73,18 @@ describe('MutantGenerator', () => {
       const boundaryMutation = result.find(
         m => m.mutationName === 'BoundaryConditionMutator'
       )
+      const removeIncrementsMutation = result.find(
+        m => m.mutationName === 'RemoveIncrementsMutator'
+      )
 
       expect(incrementMutation).toBeDefined()
       expect(incrementMutation?.replacement).toBe('--')
 
       expect(boundaryMutation).toBeDefined()
       expect(boundaryMutation?.replacement).toBe('<=')
+
+      expect(removeIncrementsMutation).toBeDefined()
+      expect(removeIncrementsMutation?.replacement).toBe('i')
     })
   })
 


### PR DESCRIPTION
# Explain your changes

Implements the RemoveIncrementsMutator that removes increment and decrement operations from code. This mutator transforms `i++`, `i--`, `++i`, and `--i` into simply `i`.

The implementation:
- Extends `BaseListener` and hooks into `enterPostOpExpression` and `enterPreOpExpression`
- Removes `++` and `--` operators from expressions
- Ignores unary `+` and `-` operators (not increments)

# Does this close any currently open issues?

closes #41

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

Run the mutation testing against Apex code containing increment operations:
- `i++` → `i`
- `i--` → `i`
- `++i` → `i`
- `--i` → `i`

# Any other comments

Part of v1.3 mutator implementation series.