### PR TITLE
feat: add void method call mutator

### DIFF
--- a/src/mutator/voidMethodCallMutator.ts
+++ b/src/mutator/voidMethodCallMutator.ts
@@ -1,0 +1,28 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { BaseListener } from './baseListener.js'
+
+export class VoidMethodCallMutator extends BaseListener {
+  // Expression contexts that represent method calls
+  private readonly METHOD_CALL_CONTEXTS = new Set([
+    'MethodCallExpressionContext',
+    'DotExpressionContext',
+  ])
+
+  // Handle expression statements (method();)
+  enterExpressionStatement(ctx: ParserRuleContext): void {
+    if (ctx.childCount !== 2) {
+      return
+    }
+
+    const expression = ctx.getChild(0)
+
+    // Check if the expression is a method call
+    const contextName = expression?.constructor?.name
+    if (!contextName || !this.METHOD_CALL_CONTEXTS.has(contextName)) {
+      return
+    }
+
+    // Remove the entire statement (replace with empty string)
+    this.createMutationFromParserRuleContext(ctx, '')
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -20,6 +20,7 @@ import { NegationMutator } from '../mutator/negationMutator.js'
 import { NullReturnMutator } from '../mutator/nullReturnMutator.js'
 import { RemoveIncrementsMutator } from '../mutator/removeIncrementsMutator.js'
 import { TrueReturnMutator } from '../mutator/trueReturnMutator.js'
+import { VoidMethodCallMutator } from '../mutator/voidMethodCallMutator.js'
 import { ApexMutation } from '../type/ApexMutation.js'
 import { ApexTypeResolver } from './apexTypeResolver.js'
 
@@ -56,6 +57,7 @@ export class MutantGenerator {
     const logicalOperatorListener = new LogicalOperatorMutator()
     const negationListener = new NegationMutator()
     const removeIncrementsListener = new RemoveIncrementsMutator()
+    const voidMethodCallListener = new VoidMethodCallMutator()
 
     const listener = new MutationListener(
       [
@@ -71,6 +73,7 @@ export class MutantGenerator {
         logicalOperatorListener,
         negationListener,
         removeIncrementsListener,
+        voidMethodCallListener,
       ],
       coveredLines,
       methodTypeTable

--- a/test/integration/voidMethodCallMutator.integration.test.ts
+++ b/test/integration/voidMethodCallMutator.integration.test.ts
@@ -1,0 +1,184 @@
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+import { VoidMethodCallMutator } from '../../src/mutator/voidMethodCallMutator.js'
+
+describe('VoidMethodCallMutator Integration', () => {
+  const parseAndMutate = (code: string, coveredLines: Set<number>) => {
+    const lexer = new ApexLexer(new CaseInsensitiveInputStream('test', code))
+    const tokenStream = new CommonTokenStream(lexer)
+    const parser = new ApexParser(tokenStream)
+    const tree = parser.compilationUnit()
+
+    const voidMethodCallMutator = new VoidMethodCallMutator()
+    const listener = new MutationListener([voidMethodCallMutator], coveredLines)
+
+    ParseTreeWalker.DEFAULT.walk(listener as ApexParserListener, tree)
+    return listener.getMutations()
+  }
+
+  describe('Given Apex code with System.debug call', () => {
+    it('Then should generate mutation to remove the call', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            System.debug('test');
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('')
+      expect(mutations[0].mutationName).toBe('VoidMethodCallMutator')
+    })
+  })
+
+  describe('Given Apex code with simple method call', () => {
+    it('Then should generate mutation to remove the call', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            doSomething();
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('')
+    })
+  })
+
+  describe('Given Apex code with object method call', () => {
+    it('Then should generate mutation to remove the call', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            someLogger.log('message');
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('')
+    })
+  })
+
+  describe('Given Apex code with multiple void method calls', () => {
+    it('Then should generate mutations for each call', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            System.debug('start');
+            doSomething();
+            System.debug('end');
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4, 5, 6]))
+
+      // Assert
+      expect(mutations.length).toBe(3)
+    })
+  })
+
+  describe('Given Apex code with assignment (not void call)', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Integer x = getValue();
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with return statement', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Integer test() {
+            return getValue();
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with void call on uncovered lines', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            System.debug('test');
+          }
+        }
+      `
+
+      // Act - line 4 is not covered
+      const mutations = parseAndMutate(code, new Set([5]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with DML operations', () => {
+    it('Then should generate mutation for insert call', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            insert account;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert - DML is handled differently, not as expression statement
+      // This tests that we don't crash on DML
+      expect(mutations.length).toBe(0)
+    })
+  })
+})

--- a/test/unit/mutator/voidMethodCallMutator.test.ts
+++ b/test/unit/mutator/voidMethodCallMutator.test.ts
@@ -1,0 +1,162 @@
+import { ParserRuleContext, Token } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { VoidMethodCallMutator } from '../../../src/mutator/voidMethodCallMutator.js'
+
+describe('VoidMethodCallMutator', () => {
+  let sut: VoidMethodCallMutator
+
+  beforeEach(() => {
+    sut = new VoidMethodCallMutator()
+  })
+
+  describe('Given an ExpressionStatement with a method call', () => {
+    describe('When entering the statement', () => {
+      it('Then should create mutation to remove the method call', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 25,
+        } as Token
+
+        const methodCallExpression = {
+          text: 'doSomething()',
+          constructor: { name: 'MethodCallExpressionContext' },
+        } as unknown as ParserRuleContext
+
+        const semicolonNode = new TerminalNode({ text: ';' } as Token)
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? methodCallExpression : semicolonNode
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: 'doSomething();',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterExpressionStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('')
+        expect(sut._mutations[0].mutationName).toBe('VoidMethodCallMutator')
+      })
+    })
+  })
+
+  describe('Given an ExpressionStatement with a dot expression method call', () => {
+    describe('When entering the statement', () => {
+      it('Then should create mutation to remove the method call', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 30,
+        } as Token
+
+        const dotExpression = {
+          text: "System.debug('test')",
+          constructor: { name: 'DotExpressionContext' },
+        } as unknown as ParserRuleContext
+
+        const semicolonNode = new TerminalNode({ text: ';' } as Token)
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? dotExpression : semicolonNode
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: "System.debug('test');",
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterExpressionStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('')
+      })
+    })
+  })
+
+  describe('Given an ExpressionStatement with an assignment', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const assignExpression = {
+          text: 'x = 5',
+          constructor: { name: 'AssignExpressionContext' },
+        } as unknown as ParserRuleContext
+
+        const semicolonNode = new TerminalNode({ text: ';' } as Token)
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? assignExpression : semicolonNode
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterExpressionStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given an ExpressionStatement with increment expression', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const postOpExpression = {
+          text: 'i++',
+          constructor: { name: 'PostOpExpressionContext' },
+        } as unknown as ParserRuleContext
+
+        const semicolonNode = new TerminalNode({ text: ';' } as Token)
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? postOpExpression : semicolonNode
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterExpressionStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given an ExpressionStatement with wrong number of children', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 3,
+          getChild: () => ({}),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterExpressionStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Explain your changes

Implements the VoidMethodCallMutator that removes calls to void methods (side-effect methods that don't return a value).

Examples of mutations:
- `System.debug('test');` → removed entirely
- `doSomething();` → removed entirely
- `logger.log('message');` → removed entirely

This tests whether the removal of non-returning methods (e.g., logging or state-altering methods) impacts the observable program behavior.

# Does this close any currently open issues?

closes #33

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

Run the mutation testing against Apex code containing void method calls like `System.debug()`, standalone method calls, or object method calls.

# Any other comments

Part of v1.3 mutator implementation series.