### PR TITLE
feat: add constructor call mutator

### DIFF
--- a/src/mutator/constructorCallMutator.ts
+++ b/src/mutator/constructorCallMutator.ts
@@ -1,0 +1,26 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { BaseListener } from './baseListener.js'
+
+export class ConstructorCallMutator extends BaseListener {
+  // Handle new expressions: new Account() -> null
+  enterNewExpression(ctx: ParserRuleContext): void {
+    if (ctx.childCount !== 2) {
+      return
+    }
+
+    const newKeyword = ctx.getChild(0)
+
+    // Verify it's a 'new' keyword
+    if (!(newKeyword instanceof TerminalNode)) {
+      return
+    }
+
+    if (newKeyword.text.toLowerCase() !== 'new') {
+      return
+    }
+
+    // Replace the entire new expression with null
+    this.createMutationFromParserRuleContext(ctx, 'null')
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -9,6 +9,7 @@ import {
 } from 'apex-parser'
 import { ArithmeticOperatorMutator } from '../mutator/arithmeticOperatorMutator.js'
 import { BoundaryConditionMutator } from '../mutator/boundaryConditionMutator.js'
+import { ConstructorCallMutator } from '../mutator/constructorCallMutator.js'
 import { EmptyReturnMutator } from '../mutator/emptyReturnMutator.js'
 import { EqualityConditionMutator } from '../mutator/equalityConditionMutator.js'
 import { FalseReturnMutator } from '../mutator/falseReturnMutator.js'
@@ -58,6 +59,7 @@ export class MutantGenerator {
     const negationListener = new NegationMutator()
     const removeIncrementsListener = new RemoveIncrementsMutator()
     const voidMethodCallListener = new VoidMethodCallMutator()
+    const constructorCallListener = new ConstructorCallMutator()
 
     const listener = new MutationListener(
       [
@@ -74,6 +76,7 @@ export class MutantGenerator {
         negationListener,
         removeIncrementsListener,
         voidMethodCallListener,
+        constructorCallListener,
       ],
       coveredLines,
       methodTypeTable

--- a/test/integration/constructorCallMutator.integration.test.ts
+++ b/test/integration/constructorCallMutator.integration.test.ts
@@ -1,0 +1,190 @@
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { ConstructorCallMutator } from '../../src/mutator/constructorCallMutator.js'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+
+describe('ConstructorCallMutator Integration', () => {
+  const parseAndMutate = (code: string, coveredLines: Set<number>) => {
+    const lexer = new ApexLexer(new CaseInsensitiveInputStream('test', code))
+    const tokenStream = new CommonTokenStream(lexer)
+    const parser = new ApexParser(tokenStream)
+    const tree = parser.compilationUnit()
+
+    const constructorCallMutator = new ConstructorCallMutator()
+    const listener = new MutationListener(
+      [constructorCallMutator],
+      coveredLines
+    )
+
+    ParseTreeWalker.DEFAULT.walk(listener as ApexParserListener, tree)
+    return listener.getMutations()
+  }
+
+  describe('Given Apex code with simple constructor call', () => {
+    it('Then should generate mutation replacing with null', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Account acc = new Account();
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('null')
+      expect(mutations[0].mutationName).toBe('ConstructorCallMutator')
+    })
+  })
+
+  describe('Given Apex code with generic type constructor', () => {
+    it('Then should generate mutation replacing with null', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            List<String> items = new List<String>();
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('null')
+    })
+  })
+
+  describe('Given Apex code with constructor with arguments', () => {
+    it('Then should generate mutation replacing with null', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Account acc = new Account(Name = 'Test');
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('null')
+    })
+  })
+
+  describe('Given Apex code with multiple constructor calls', () => {
+    it('Then should generate mutations for each constructor', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Account acc = new Account();
+            Contact con = new Contact();
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4, 5]))
+
+      // Assert
+      expect(mutations.length).toBe(2)
+      expect(mutations[0].replacement).toBe('null')
+      expect(mutations[1].replacement).toBe('null')
+    })
+  })
+
+  describe('Given Apex code with Map constructor', () => {
+    it('Then should generate mutation replacing with null', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Map<String, Object> data = new Map<String, Object>();
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('null')
+    })
+  })
+
+  describe('Given Apex code with Set constructor', () => {
+    it('Then should generate mutation replacing with null', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Set<Id> ids = new Set<Id>();
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('null')
+    })
+  })
+
+  describe('Given Apex code with constructor on uncovered lines', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            Account acc = new Account();
+          }
+        }
+      `
+
+      // Act - line 4 is not covered
+      const mutations = parseAndMutate(code, new Set([5]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with nested constructor calls', () => {
+    it('Then should generate mutations for inner constructors', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            insert new Account(Name = 'Test');
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('null')
+    })
+  })
+})

--- a/test/unit/mutator/constructorCallMutator.test.ts
+++ b/test/unit/mutator/constructorCallMutator.test.ts
@@ -1,0 +1,164 @@
+import { ParserRuleContext, Token } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { ConstructorCallMutator } from '../../../src/mutator/constructorCallMutator.js'
+
+describe('ConstructorCallMutator', () => {
+  let sut: ConstructorCallMutator
+
+  beforeEach(() => {
+    sut = new ConstructorCallMutator()
+  })
+
+  describe('Given a NewExpression with constructor call', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation replacing with null', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 25,
+        } as Token
+
+        const newKeyword = new TerminalNode({ text: 'new' } as Token)
+
+        const creatorCtx = {
+          text: 'Account()',
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? newKeyword : creatorCtx
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: 'new Account()',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterNewExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('null')
+        expect(sut._mutations[0].mutationName).toBe('ConstructorCallMutator')
+      })
+    })
+  })
+
+  describe('Given a NewExpression with generic type', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation replacing with null', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 30,
+        } as Token
+
+        const newKeyword = new TerminalNode({ text: 'new' } as Token)
+
+        const creatorCtx = {
+          text: 'List<String>()',
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? newKeyword : creatorCtx
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: 'new List<String>()',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterNewExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('null')
+      })
+    })
+  })
+
+  describe('Given a NewExpression with constructor arguments', () => {
+    describe('When entering the expression', () => {
+      it('Then should create mutation replacing with null', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 35,
+        } as Token
+
+        const newKeyword = new TerminalNode({ text: 'new' } as Token)
+
+        const creatorCtx = {
+          text: "Account(Name = 'Test')",
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(index => {
+            return index === 0 ? newKeyword : creatorCtx
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 6 } as Token,
+          text: "new Account(Name = 'Test')",
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterNewExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('null')
+      })
+    })
+  })
+
+  describe('Given an expression with wrong number of children', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 3,
+          getChild: () => ({}),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterNewExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given an expression where first child is not new keyword', () => {
+    describe('When entering the expression', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 2,
+          getChild: jest.fn().mockImplementation(() => {
+            return { text: 'something' } // Not a TerminalNode
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterNewExpression(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Explain your changes

Implements the ConstructorCallMutator that replaces constructor calls with `null`.

Examples of mutations:
- `new Account()` → `null`
- `new List<String>()` → `null`
- `new Account(Name = 'Test')` → `null`

This tests whether code properly handles NullPointerException scenarios and validates object creation dependencies.

# Does this close any currently open issues?

closes #28

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

Run the mutation testing against Apex code containing constructor calls like `new Account()`, `new List<String>()`, or `new Map<String, Object>()`.

# Any other comments

Part of v1.3 mutator implementation series.