### PR TITLE
feat: add remove conditionals mutator

### DIFF
--- a/src/mutator/removeConditionalsMutator.ts
+++ b/src/mutator/removeConditionalsMutator.ts
@@ -1,0 +1,33 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { BaseListener } from './baseListener.js'
+
+export class RemoveConditionalsMutator extends BaseListener {
+  // Handle if statements: if (condition) -> if (true) or if (false)
+  enterIfStatement(ctx: ParserRuleContext): void {
+    // if statement structure: 'if', parExpression, statement, ['else', statement]
+    if (ctx.childCount < 3) {
+      return
+    }
+
+    const ifKeyword = ctx.getChild(0)
+
+    // Verify it's an 'if' keyword
+    if (!(ifKeyword instanceof TerminalNode)) {
+      return
+    }
+
+    if (ifKeyword.text.toLowerCase() !== 'if') {
+      return
+    }
+
+    // Get the condition (child 1 is the ParExpression)
+    const conditionCtx = ctx.getChild(1) as ParserRuleContext
+
+    // Replace condition with (true) - always execute if block
+    this.createMutationFromParserRuleContext(conditionCtx, '(true)')
+
+    // Replace condition with (false) - never execute if block
+    this.createMutationFromParserRuleContext(conditionCtx, '(false)')
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -19,6 +19,7 @@ import { LogicalOperatorMutator } from '../mutator/logicalOperatorMutator.js'
 import { MutationListener } from '../mutator/mutationListener.js'
 import { NegationMutator } from '../mutator/negationMutator.js'
 import { NullReturnMutator } from '../mutator/nullReturnMutator.js'
+import { RemoveConditionalsMutator } from '../mutator/removeConditionalsMutator.js'
 import { RemoveIncrementsMutator } from '../mutator/removeIncrementsMutator.js'
 import { TrueReturnMutator } from '../mutator/trueReturnMutator.js'
 import { VoidMethodCallMutator } from '../mutator/voidMethodCallMutator.js'
@@ -60,6 +61,7 @@ export class MutantGenerator {
     const removeIncrementsListener = new RemoveIncrementsMutator()
     const voidMethodCallListener = new VoidMethodCallMutator()
     const constructorCallListener = new ConstructorCallMutator()
+    const removeConditionalsListener = new RemoveConditionalsMutator()
 
     const listener = new MutationListener(
       [
@@ -77,6 +79,7 @@ export class MutantGenerator {
         removeIncrementsListener,
         voidMethodCallListener,
         constructorCallListener,
+        removeConditionalsListener,
       ],
       coveredLines,
       methodTypeTable

--- a/test/integration/removeConditionalsMutator.integration.test.ts
+++ b/test/integration/removeConditionalsMutator.integration.test.ts
@@ -1,0 +1,191 @@
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+import { RemoveConditionalsMutator } from '../../src/mutator/removeConditionalsMutator.js'
+
+describe('RemoveConditionalsMutator Integration', () => {
+  const parseAndMutate = (code: string, coveredLines: Set<number>) => {
+    const lexer = new ApexLexer(new CaseInsensitiveInputStream('test', code))
+    const tokenStream = new CommonTokenStream(lexer)
+    const parser = new ApexParser(tokenStream)
+    const tree = parser.compilationUnit()
+
+    const removeConditionalsMutator = new RemoveConditionalsMutator()
+    const listener = new MutationListener(
+      [removeConditionalsMutator],
+      coveredLines
+    )
+
+    ParseTreeWalker.DEFAULT.walk(listener as ApexParserListener, tree)
+    return listener.getMutations()
+  }
+
+  describe('Given Apex code with simple if statement', () => {
+    it('Then should generate mutations replacing condition with true and false', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            if (x > 0) {
+              doSomething();
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(2)
+      expect(mutations[0].replacement).toBe('(true)')
+      expect(mutations[1].replacement).toBe('(false)')
+      expect(mutations[0].mutationName).toBe('RemoveConditionalsMutator')
+    })
+  })
+
+  describe('Given Apex code with if-else statement', () => {
+    it('Then should generate mutations for the condition', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            if (condition) {
+              doA();
+            } else {
+              doB();
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(2)
+      expect(mutations[0].replacement).toBe('(true)')
+      expect(mutations[1].replacement).toBe('(false)')
+    })
+  })
+
+  describe('Given Apex code with nested if statements', () => {
+    it('Then should generate mutations for each if statement', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            if (outer) {
+              if (inner) {
+                doSomething();
+              }
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4, 5]))
+
+      // Assert
+      // 2 mutations for outer if, 2 for inner if
+      expect(mutations.length).toBe(4)
+    })
+  })
+
+  describe('Given Apex code with else-if chain', () => {
+    it('Then should generate mutations for each condition', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            if (a) {
+              doA();
+            } else if (b) {
+              doB();
+            } else {
+              doC();
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4, 6]))
+
+      // Assert
+      // 2 mutations for first if, 2 for else-if
+      expect(mutations.length).toBe(4)
+    })
+  })
+
+  describe('Given Apex code with complex condition', () => {
+    it('Then should generate mutations for the whole condition', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            if (a && b || c) {
+              doSomething();
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(2)
+      expect(mutations[0].replacement).toBe('(true)')
+      expect(mutations[1].replacement).toBe('(false)')
+    })
+  })
+
+  describe('Given Apex code with if on uncovered lines', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test() {
+            if (x > 0) {
+              doSomething();
+            }
+          }
+        }
+      `
+
+      // Act - line 4 is not covered
+      const mutations = parseAndMutate(code, new Set([5]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with ternary operator', () => {
+    it('Then should not generate mutations for ternary', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public Integer test() {
+            return x > 0 ? 1 : 0;
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      // Ternary is not an IfStatement, so no mutations
+      expect(mutations.length).toBe(0)
+    })
+  })
+})

--- a/test/unit/mutator/removeConditionalsMutator.test.ts
+++ b/test/unit/mutator/removeConditionalsMutator.test.ts
@@ -1,0 +1,152 @@
+import { ParserRuleContext, Token } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { RemoveConditionalsMutator } from '../../../src/mutator/removeConditionalsMutator.js'
+
+describe('RemoveConditionalsMutator', () => {
+  let sut: RemoveConditionalsMutator
+
+  beforeEach(() => {
+    sut = new RemoveConditionalsMutator()
+  })
+
+  describe('Given an IfStatement with a condition', () => {
+    describe('When entering the statement', () => {
+      it('Then should create mutations to replace condition with true and false', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 25,
+        } as Token
+
+        const ifKeyword = new TerminalNode({ text: 'if' } as Token)
+
+        const conditionCtx = {
+          text: '(x > 0)',
+          start: mockToken,
+          stop: { tokenIndex: 8 } as Token,
+        } as unknown as ParserRuleContext
+
+        const thenBlock = {
+          text: '{ doA(); }',
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 0) return ifKeyword
+            if (index === 1) return conditionCtx
+            return thenBlock
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 10 } as Token,
+          text: 'if (x > 0) { doA(); }',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterIfStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(2)
+        expect(sut._mutations[0].replacement).toBe('(true)')
+        expect(sut._mutations[1].replacement).toBe('(false)')
+        expect(sut._mutations[0].mutationName).toBe('RemoveConditionalsMutator')
+      })
+    })
+  })
+
+  describe('Given an IfStatement with else block', () => {
+    describe('When entering the statement', () => {
+      it('Then should create mutations for the condition', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 40,
+        } as Token
+
+        const ifKeyword = new TerminalNode({ text: 'if' } as Token)
+
+        const conditionCtx = {
+          text: '(condition)',
+          start: mockToken,
+          stop: { tokenIndex: 8 } as Token,
+        } as unknown as ParserRuleContext
+
+        const thenBlock = {
+          text: '{ doA(); }',
+        } as unknown as ParserRuleContext
+
+        const elseKeyword = new TerminalNode({ text: 'else' } as Token)
+
+        const elseBlock = {
+          text: '{ doB(); }',
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 5,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 0) return ifKeyword
+            if (index === 1) return conditionCtx
+            if (index === 2) return thenBlock
+            if (index === 3) return elseKeyword
+            return elseBlock
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 15 } as Token,
+          text: 'if (condition) { doA(); } else { doB(); }',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterIfStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(2)
+        expect(sut._mutations[0].replacement).toBe('(true)')
+        expect(sut._mutations[1].replacement).toBe('(false)')
+      })
+    })
+  })
+
+  describe('Given an IfStatement with too few children', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 2, // Not enough children
+          getChild: () => ({}),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterIfStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given an IfStatement where first child is not if keyword', () => {
+    describe('When entering the statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(() => {
+            return { text: 'something' } // Not a TerminalNode
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterIfStatement(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Explain your changes

Implements the RemoveConditionalsMutator that replaces conditional expressions with fixed values (`true` or `false`).

Examples of mutations:
- `if (x > 0)` → `if (true)` (always execute if block)
- `if (x > 0)` → `if (false)` (never execute if block)

This tests whether the test suite catches unintended outcomes when conditional statements are ignored or always/never executed.

# Does this close any currently open issues?

closes #37

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

Run the mutation testing against Apex code containing if statements, else-if chains, and nested conditionals.

# Any other comments

Part of v1.3 mutator implementation series.