### PR TITLE
feat: add switch mutator

### DIFF
--- a/src/mutator/switchMutator.ts
+++ b/src/mutator/switchMutator.ts
@@ -1,0 +1,30 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { BaseListener } from './baseListener.js'
+
+export class SwitchMutator extends BaseListener {
+  // Handle when control blocks: when 1 { code } -> when 1 {}
+  enterWhenControl(ctx: ParserRuleContext): void {
+    // WhenControl structure: 'when', whenValue, block
+    if (ctx.childCount !== 3) {
+      return
+    }
+
+    const whenKeyword = ctx.getChild(0)
+
+    // Verify it's a 'when' keyword
+    if (!(whenKeyword instanceof TerminalNode)) {
+      return
+    }
+
+    if (whenKeyword.text.toLowerCase() !== 'when') {
+      return
+    }
+
+    // Get the block (child 2)
+    const blockCtx = ctx.getChild(2) as ParserRuleContext
+
+    // Replace block with empty block
+    this.createMutationFromParserRuleContext(blockCtx, '{}')
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -21,6 +21,7 @@ import { NegationMutator } from '../mutator/negationMutator.js'
 import { NullReturnMutator } from '../mutator/nullReturnMutator.js'
 import { RemoveConditionalsMutator } from '../mutator/removeConditionalsMutator.js'
 import { RemoveIncrementsMutator } from '../mutator/removeIncrementsMutator.js'
+import { SwitchMutator } from '../mutator/switchMutator.js'
 import { TrueReturnMutator } from '../mutator/trueReturnMutator.js'
 import { VoidMethodCallMutator } from '../mutator/voidMethodCallMutator.js'
 import { ApexMutation } from '../type/ApexMutation.js'
@@ -62,6 +63,7 @@ export class MutantGenerator {
     const voidMethodCallListener = new VoidMethodCallMutator()
     const constructorCallListener = new ConstructorCallMutator()
     const removeConditionalsListener = new RemoveConditionalsMutator()
+    const switchListener = new SwitchMutator()
 
     const listener = new MutationListener(
       [
@@ -80,6 +82,7 @@ export class MutantGenerator {
         voidMethodCallListener,
         constructorCallListener,
         removeConditionalsListener,
+        switchListener,
       ],
       coveredLines,
       methodTypeTable

--- a/test/integration/switchMutator.integration.test.ts
+++ b/test/integration/switchMutator.integration.test.ts
@@ -1,0 +1,161 @@
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+import { SwitchMutator } from '../../src/mutator/switchMutator.js'
+
+describe('SwitchMutator Integration', () => {
+  const parseAndMutate = (code: string, coveredLines: Set<number>) => {
+    const lexer = new ApexLexer(new CaseInsensitiveInputStream('test', code))
+    const tokenStream = new CommonTokenStream(lexer)
+    const parser = new ApexParser(tokenStream)
+    const tree = parser.compilationUnit()
+
+    const switchMutator = new SwitchMutator()
+    const listener = new MutationListener([switchMutator], coveredLines)
+
+    ParseTreeWalker.DEFAULT.walk(listener as ApexParserListener, tree)
+    return listener.getMutations()
+  }
+
+  describe('Given Apex code with switch statement with multiple cases', () => {
+    it('Then should generate mutations for each when clause', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test(Integer value) {
+            switch on value {
+              when 1 {
+                handle1();
+              }
+              when 2 {
+                handle2();
+              }
+              when else {
+                handleDefault();
+              }
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([5, 8, 11]))
+
+      // Assert
+      expect(mutations.length).toBe(3) // One for each when clause
+      mutations.forEach(m => {
+        expect(m.replacement).toBe('{}')
+        expect(m.mutationName).toBe('SwitchMutator')
+      })
+    })
+  })
+
+  describe('Given Apex code with switch statement with single case', () => {
+    it('Then should generate mutation for the case', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test(Integer value) {
+            switch on value {
+              when 1 {
+                doSomething();
+              }
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([5]))
+
+      // Assert
+      expect(mutations.length).toBe(1)
+      expect(mutations[0].replacement).toBe('{}')
+    })
+  })
+
+  describe('Given Apex code with switch on SObject type', () => {
+    it('Then should generate mutations for type cases', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test(SObject obj) {
+            switch on obj {
+              when Account acc {
+                handleAccount(acc);
+              }
+              when Contact con {
+                handleContact(con);
+              }
+              when else {
+                handleOther();
+              }
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([5, 8, 11]))
+
+      // Assert
+      expect(mutations.length).toBe(3)
+    })
+  })
+
+  describe('Given Apex code with switch statement on uncovered lines', () => {
+    it('Then should not generate mutations', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public void test(Integer value) {
+            switch on value {
+              when 1 {
+                handle1();
+              }
+            }
+          }
+        }
+      `
+
+      // Act - when clause is not covered
+      const mutations = parseAndMutate(code, new Set([4]))
+
+      // Assert
+      expect(mutations.length).toBe(0)
+    })
+  })
+
+  describe('Given Apex code with switch on enum', () => {
+    it('Then should generate mutations for enum cases', () => {
+      // Arrange
+      const code = `
+        public class TestClass {
+          public enum Status { ACTIVE, INACTIVE }
+          public void test(Status s) {
+            switch on s {
+              when ACTIVE {
+                handleActive();
+              }
+              when INACTIVE {
+                handleInactive();
+              }
+            }
+          }
+        }
+      `
+
+      // Act
+      const mutations = parseAndMutate(code, new Set([6, 9]))
+
+      // Assert
+      expect(mutations.length).toBe(2)
+    })
+  })
+})

--- a/test/unit/mutator/switchMutator.test.ts
+++ b/test/unit/mutator/switchMutator.test.ts
@@ -1,0 +1,142 @@
+import { ParserRuleContext, Token } from 'antlr4ts'
+import { TerminalNode } from 'antlr4ts/tree/index.js'
+import { SwitchMutator } from '../../../src/mutator/switchMutator.js'
+
+describe('SwitchMutator', () => {
+  let sut: SwitchMutator
+
+  beforeEach(() => {
+    sut = new SwitchMutator()
+  })
+
+  describe('Given a WhenControl with a block', () => {
+    describe('When entering the when control', () => {
+      it('Then should create mutation to remove the block body', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 30,
+        } as Token
+
+        const whenKeyword = new TerminalNode({ text: 'when' } as Token)
+
+        const whenValueCtx = {
+          text: '1',
+        } as unknown as ParserRuleContext
+
+        const blockCtx = {
+          text: '{ handle1(); }',
+          start: { tokenIndex: 7 } as Token,
+          stop: { tokenIndex: 10 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 0) return whenKeyword
+            if (index === 1) return whenValueCtx
+            return blockCtx
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 10 } as Token,
+          text: 'when 1 { handle1(); }',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterWhenControl(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('{}')
+        expect(sut._mutations[0].mutationName).toBe('SwitchMutator')
+      })
+    })
+  })
+
+  describe('Given a WhenControl for else case', () => {
+    describe('When entering the when control', () => {
+      it('Then should create mutation to remove the else block body', () => {
+        // Arrange
+        const mockToken = {
+          line: 1,
+          charPositionInLine: 10,
+          tokenIndex: 5,
+          startIndex: 10,
+          stopIndex: 35,
+        } as Token
+
+        const whenKeyword = new TerminalNode({ text: 'when' } as Token)
+
+        const whenValueCtx = {
+          text: 'else',
+        } as unknown as ParserRuleContext
+
+        const blockCtx = {
+          text: '{ handleDefault(); }',
+          start: { tokenIndex: 7 } as Token,
+          stop: { tokenIndex: 12 } as Token,
+        } as unknown as ParserRuleContext
+
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(index => {
+            if (index === 0) return whenKeyword
+            if (index === 1) return whenValueCtx
+            return blockCtx
+          }),
+          start: mockToken,
+          stop: { tokenIndex: 12 } as Token,
+          text: 'when else { handleDefault(); }',
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterWhenControl(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('{}')
+      })
+    })
+  })
+
+  describe('Given a WhenControl with wrong number of children', () => {
+    describe('When entering the when control', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 2, // Not enough children
+          getChild: () => ({}),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterWhenControl(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a WhenControl where first child is not when keyword', () => {
+    describe('When entering the when control', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const ctx = {
+          childCount: 3,
+          getChild: jest.fn().mockImplementation(() => {
+            return { text: 'something' } // Not a TerminalNode
+          }),
+        } as unknown as ParserRuleContext
+
+        // Act
+        sut.enterWhenControl(ctx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Explain your changes

Implements the SwitchMutator that removes case block bodies in switch statements.

Examples of mutations:
- `when 1 { handle1(); }` → `when 1 {}`
- `when else { handleDefault(); }` → `when else {}`

This tests whether the test suite can detect incorrect or incomplete switch statement logic when case handlers are removed.

# Does this close any currently open issues?

closes #38

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

Run the mutation testing against Apex code containing switch statements with multiple when clauses.

# Any other comments

Part of v1.3 mutator implementation series.