### PR TITLE
feat: add ZeroReturnMutator for numeric return types

### DIFF
--- a/src/mutator/zeroReturnMutator.ts
+++ b/src/mutator/zeroReturnMutator.ts
@@ -1,0 +1,44 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { ApexType } from '../type/ApexMethod.js'
+import { ReturnTypeAwareBaseListener } from './returnTypeAwareBaseListener.js'
+
+export class ZeroReturnMutator extends ReturnTypeAwareBaseListener {
+  // Numeric types that should return 0
+  private readonly NUMERIC_TYPES = new Set([
+    ApexType.INTEGER,
+    ApexType.LONG,
+    ApexType.DOUBLE,
+    ApexType.DECIMAL,
+  ])
+
+  enterReturnStatement(ctx: ParserRuleContext): void {
+    if (!this.isCurrentMethodTypeKnown()) {
+      return
+    }
+
+    const typeInfo = this.getCurrentMethodReturnTypeInfo()
+    if (!typeInfo) {
+      return
+    }
+
+    if (!this.NUMERIC_TYPES.has(typeInfo.type)) {
+      return
+    }
+
+    if (!ctx.children || ctx.children.length < 2) {
+      return
+    }
+
+    const expressionNode = ctx.children[1]
+    if (!(expressionNode instanceof ParserRuleContext)) {
+      return
+    }
+
+    // Skip if already returning 0
+    if (expressionNode.text.trim() === '0') {
+      return
+    }
+
+    this.createMutationFromParserRuleContext(expressionNode, '0')
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -16,6 +16,7 @@ import { IncrementMutator } from '../mutator/incrementMutator.js'
 import { MutationListener } from '../mutator/mutationListener.js'
 import { NullReturnMutator } from '../mutator/nullReturnMutator.js'
 import { TrueReturnMutator } from '../mutator/trueReturnMutator.js'
+import { ZeroReturnMutator } from '../mutator/zeroReturnMutator.js'
 import { ApexMutation } from '../type/ApexMutation.js'
 import { ApexTypeResolver } from './apexTypeResolver.js'
 
@@ -46,6 +47,7 @@ export class MutantGenerator {
     const trueReturnListener = new TrueReturnMutator()
     const falseReturnListener = new FalseReturnMutator()
     const nullReturnListener = new NullReturnMutator()
+    const zeroReturnListener = new ZeroReturnMutator()
     const equalityListener = new EqualityConditionMutator()
     const arithmeticListener = new ArithmeticOperatorMutator()
 
@@ -58,6 +60,7 @@ export class MutantGenerator {
         trueReturnListener,
         falseReturnListener,
         nullReturnListener,
+        zeroReturnListener,
         arithmeticListener,
       ],
       coveredLines,

--- a/test/integration/zeroReturnMutator.integration.test.ts
+++ b/test/integration/zeroReturnMutator.integration.test.ts
@@ -1,0 +1,500 @@
+import { ParserRuleContext } from 'antlr4ts'
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+import { ZeroReturnMutator } from '../../src/mutator/zeroReturnMutator.js'
+import { ApexTypeResolver } from '../../src/service/apexTypeResolver.js'
+import { MutantGenerator } from '../../src/service/mutantGenerator.js'
+import { ApexMethod, ApexType } from '../../src/type/ApexMethod.js'
+
+function parseApexAndGetTypeTable(code: string): Map<string, ApexMethod> {
+  const input = new CaseInsensitiveInputStream('other', code)
+  const lexer = new ApexLexer(input)
+  const tokens = new CommonTokenStream(lexer)
+  const parser = new ApexParser(tokens)
+  const tree = parser.compilationUnit()
+
+  const resolver = new ApexTypeResolver()
+  const typeTable = resolver.analyzeMethodTypes(tree as ParserRuleContext)
+  return typeTable
+}
+
+describe('ZeroReturnMutator Integration', () => {
+  let mutantGenerator: MutantGenerator
+
+  beforeEach(() => {
+    mutantGenerator = new MutantGenerator()
+  })
+
+  describe('when mutating Integer return statements', () => {
+    it('should create mutations for Integer return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Integer getCount() {
+              return 42;
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getCount', {
+        returnType: 'Integer',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.INTEGER,
+      })
+
+      const zeroReturnMutator = new ZeroReturnMutator()
+      zeroReturnMutator.setTypeTable(typeTable)
+      zeroReturnMutator['currentMethodName'] = 'getCount'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [zeroReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const zeroReturnMutations = mutations.filter(
+        m => m.mutationName === 'ZeroReturnMutator'
+      )
+      expect(zeroReturnMutations.length).toBeGreaterThan(0)
+
+      if (zeroReturnMutations.length > 0) {
+        expect(zeroReturnMutations[0].replacement).toBe('0')
+
+        // Test actual mutation
+        const result = mutantGenerator.mutate(zeroReturnMutations[0])
+        expect(result).toContain('return 0;')
+        expect(result).not.toContain('return 42;')
+      }
+    })
+
+    it('should create mutations for Integer expressions', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Integer calculate(Integer a, Integer b) {
+              return a + b;
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('calculate', {
+        returnType: 'Integer',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.INTEGER,
+      })
+
+      const zeroReturnMutator = new ZeroReturnMutator()
+      zeroReturnMutator.setTypeTable(typeTable)
+      zeroReturnMutator['currentMethodName'] = 'calculate'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [zeroReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const zeroReturnMutations = mutations.filter(
+        m => m.mutationName === 'ZeroReturnMutator'
+      )
+      expect(zeroReturnMutations.length).toBeGreaterThan(0)
+
+      if (zeroReturnMutations.length > 0) {
+        expect(zeroReturnMutations[0].replacement).toBe('0')
+
+        const result = mutantGenerator.mutate(zeroReturnMutations[0])
+        expect(result).toContain('return 0;')
+        expect(result).not.toContain('return a + b;')
+      }
+    })
+  })
+
+  describe('when mutating Long return statements', () => {
+    it('should create mutations for Long return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Long getBigNumber() {
+              return 9999999999L;
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getBigNumber', {
+        returnType: 'Long',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.LONG,
+      })
+
+      const zeroReturnMutator = new ZeroReturnMutator()
+      zeroReturnMutator.setTypeTable(typeTable)
+      zeroReturnMutator['currentMethodName'] = 'getBigNumber'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [zeroReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const zeroReturnMutations = mutations.filter(
+        m => m.mutationName === 'ZeroReturnMutator'
+      )
+      expect(zeroReturnMutations.length).toBeGreaterThan(0)
+
+      if (zeroReturnMutations.length > 0) {
+        expect(zeroReturnMutations[0].replacement).toBe('0')
+
+        const result = mutantGenerator.mutate(zeroReturnMutations[0])
+        expect(result).toContain('return 0;')
+        expect(result).not.toContain('return 9999999999L;')
+      }
+    })
+  })
+
+  describe('when mutating Double return statements', () => {
+    it('should create mutations for Double return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Double getPi() {
+              return 3.14159;
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getPi', {
+        returnType: 'Double',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.DOUBLE,
+      })
+
+      const zeroReturnMutator = new ZeroReturnMutator()
+      zeroReturnMutator.setTypeTable(typeTable)
+      zeroReturnMutator['currentMethodName'] = 'getPi'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [zeroReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const zeroReturnMutations = mutations.filter(
+        m => m.mutationName === 'ZeroReturnMutator'
+      )
+      expect(zeroReturnMutations.length).toBeGreaterThan(0)
+
+      if (zeroReturnMutations.length > 0) {
+        expect(zeroReturnMutations[0].replacement).toBe('0')
+
+        const result = mutantGenerator.mutate(zeroReturnMutations[0])
+        expect(result).toContain('return 0;')
+        expect(result).not.toContain('return 3.14159;')
+      }
+    })
+  })
+
+  describe('when mutating Decimal return statements', () => {
+    it('should create mutations for Decimal return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Decimal getAmount() {
+              return 99.99;
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getAmount', {
+        returnType: 'Decimal',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.DECIMAL,
+      })
+
+      const zeroReturnMutator = new ZeroReturnMutator()
+      zeroReturnMutator.setTypeTable(typeTable)
+      zeroReturnMutator['currentMethodName'] = 'getAmount'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [zeroReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const zeroReturnMutations = mutations.filter(
+        m => m.mutationName === 'ZeroReturnMutator'
+      )
+      expect(zeroReturnMutations.length).toBeGreaterThan(0)
+
+      if (zeroReturnMutations.length > 0) {
+        expect(zeroReturnMutations[0].replacement).toBe('0')
+
+        const result = mutantGenerator.mutate(zeroReturnMutations[0])
+        expect(result).toContain('return 0;')
+        expect(result).not.toContain('return 99.99;')
+      }
+    })
+  })
+
+  describe('when handling non-numeric return types', () => {
+    it('should not create mutations for String return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static String getName() {
+              return 'test';
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getName', {
+        returnType: 'String',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.STRING,
+      })
+
+      const zeroReturnMutator = new ZeroReturnMutator()
+      zeroReturnMutator.setTypeTable(typeTable)
+      zeroReturnMutator['currentMethodName'] = 'getName'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [zeroReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const zeroReturnMutations = mutations.filter(
+        m => m.mutationName === 'ZeroReturnMutator'
+      )
+      expect(zeroReturnMutations.length).toBe(0)
+    })
+
+    it('should not create mutations for Boolean return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Boolean isValid() {
+              return true;
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('isValid', {
+        returnType: 'Boolean',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.BOOLEAN,
+      })
+
+      const zeroReturnMutator = new ZeroReturnMutator()
+      zeroReturnMutator.setTypeTable(typeTable)
+      zeroReturnMutator['currentMethodName'] = 'isValid'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [zeroReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const zeroReturnMutations = mutations.filter(
+        m => m.mutationName === 'ZeroReturnMutator'
+      )
+      expect(zeroReturnMutations.length).toBe(0)
+    })
+  })
+
+  describe('when handling already zero returns', () => {
+    it('should not create mutations for already zero returns', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Integer getZero() {
+              return 0;
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getZero', {
+        returnType: 'Integer',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.INTEGER,
+      })
+
+      const zeroReturnMutator = new ZeroReturnMutator()
+      zeroReturnMutator.setTypeTable(typeTable)
+      zeroReturnMutator['currentMethodName'] = 'getZero'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [zeroReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const zeroReturnMutations = mutations.filter(
+        m => m.mutationName === 'ZeroReturnMutator'
+      )
+      expect(zeroReturnMutations.length).toBe(0)
+    })
+  })
+})

--- a/test/unit/mutator/zeroReturnMutator.test.ts
+++ b/test/unit/mutator/zeroReturnMutator.test.ts
@@ -1,0 +1,364 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { ZeroReturnMutator } from '../../../src/mutator/zeroReturnMutator.js'
+import { ApexMethod, ApexType } from '../../../src/type/ApexMethod.js'
+import { TestUtil } from '../../utils/testUtil.js'
+
+describe('ZeroReturnMutator', () => {
+  let sut: ZeroReturnMutator
+
+  beforeEach(() => {
+    sut = new ZeroReturnMutator()
+  })
+
+  describe('Given a return statement in a method returning Integer', () => {
+    describe('When entering the return statement', () => {
+      it('Then should create mutation to return 0', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Integer',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Integer',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.INTEGER,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('result')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('0')
+        expect(sut._mutations[0].mutationName).toBe('ZeroReturnMutator')
+      })
+    })
+  })
+
+  describe('Given a return statement in a method returning Double', () => {
+    describe('When entering the return statement', () => {
+      it('Then should create mutation to return 0', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Double',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Double',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.DOUBLE,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('3.14')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('0')
+      })
+    })
+  })
+
+  describe('Given a return statement in a method returning Decimal', () => {
+    describe('When entering the return statement', () => {
+      it('Then should create mutation to return 0', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Decimal',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Decimal',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.DECIMAL,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('amount')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('0')
+      })
+    })
+  })
+
+  describe('Given a return statement in a method returning Long', () => {
+    describe('When entering the return statement', () => {
+      it('Then should create mutation to return 0', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration('Long', 'testMethod')
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Long',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.LONG,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('bigNumber')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('0')
+      })
+    })
+  })
+
+  describe('Given a return statement already returning 0', () => {
+    describe('When entering the return statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Integer',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Integer',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.INTEGER,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('0')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement in a method returning String', () => {
+    describe('When entering the return statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'String',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'String',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.STRING,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement("'hello'")
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement without type information', () => {
+    describe('When entering the return statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const returnCtx = TestUtil.createReturnStatement('result')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('validation and edge cases', () => {
+    it('should handle return statement with no children', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration(
+        'Integer',
+        'testMethod'
+      )
+      sut.enterMethodDeclaration(methodCtx)
+
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'Integer',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.INTEGER,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = {
+        children: null,
+        childCount: 0,
+      } as unknown as ParserRuleContext
+
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+
+    it('should handle return statement with insufficient children', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration(
+        'Integer',
+        'testMethod'
+      )
+      sut.enterMethodDeclaration(methodCtx)
+
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'Integer',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.INTEGER,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = {
+        children: [{ text: 'return' }],
+        childCount: 1,
+      } as unknown as ParserRuleContext
+
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+
+    it('should handle non-ParserRuleContext expression node', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration(
+        'Integer',
+        'testMethod'
+      )
+      sut.enterMethodDeclaration(methodCtx)
+
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'Integer',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.INTEGER,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = {
+        children: [
+          { text: 'return' },
+          { text: '42' }, // Not a ParserRuleContext
+        ],
+        childCount: 2,
+        getChild: (i: number) =>
+          i === 0 ? { text: 'return' } : { text: '42' },
+      } as unknown as ParserRuleContext
+
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+
+    it('should handle missing method context', () => {
+      // Arrange
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'Integer',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.INTEGER,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = TestUtil.createReturnStatement('42')
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+  })
+
+  describe('method tracking', () => {
+    it('should set currentMethodName on enter', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration(
+        'Integer',
+        'testMethod'
+      )
+
+      // Act
+      sut.enterMethodDeclaration(methodCtx)
+
+      // Assert
+      expect(sut['currentMethodName']).toBe('testMethod')
+    })
+
+    it('should clear currentMethodName on exit', () => {
+      // Arrange
+      sut['currentMethodName'] = 'testMethod'
+
+      // Act
+      sut.exitMethodDeclaration()
+
+      // Assert
+      expect(sut['currentMethodName']).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implements ZeroReturnMutator as part of the Defaults Mutator (#40)
- Mutates return statements in numeric methods (Integer, Long, Double, Decimal) to return 0
- Extends ReturnTypeAwareBaseListener for type-aware mutations

## Changes
- Add `src/mutator/zeroReturnMutator.ts` - new mutator implementation
- Register ZeroReturnMutator in `mutantGenerator.ts`
- Add unit tests covering all numeric types and edge cases
- Add integration tests verifying actual code mutation

## Test plan
- [x] Unit tests pass for all numeric types (Integer, Long, Double, Decimal)
- [x] Skips mutation when already returning 0
- [x] Does not create mutations for non-numeric types (String, Boolean, etc.)
- [x] Integration tests verify actual mutation output
- [x] All existing tests continue to pass

Closes #40 (partial - ZeroReturnMutator component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)