### PR TITLE
feat: add EmptyStringReturnMutator for String return types

### DIFF
--- a/src/mutator/emptyStringReturnMutator.ts
+++ b/src/mutator/emptyStringReturnMutator.ts
@@ -1,0 +1,36 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { ApexType } from '../type/ApexMethod.js'
+import { ReturnTypeAwareBaseListener } from './returnTypeAwareBaseListener.js'
+
+export class EmptyStringReturnMutator extends ReturnTypeAwareBaseListener {
+  enterReturnStatement(ctx: ParserRuleContext): void {
+    if (!this.isCurrentMethodTypeKnown()) {
+      return
+    }
+
+    const typeInfo = this.getCurrentMethodReturnTypeInfo()
+    if (!typeInfo) {
+      return
+    }
+
+    if (typeInfo.type !== ApexType.STRING) {
+      return
+    }
+
+    if (!ctx.children || ctx.children.length < 2) {
+      return
+    }
+
+    const expressionNode = ctx.children[1]
+    if (!(expressionNode instanceof ParserRuleContext)) {
+      return
+    }
+
+    // Skip if already returning empty string
+    if (expressionNode.text.trim() === "''") {
+      return
+    }
+
+    this.createMutationFromParserRuleContext(expressionNode, "''")
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -10,6 +10,7 @@ import {
 import { ArithmeticOperatorMutator } from '../mutator/arithmeticOperatorMutator.js'
 import { BoundaryConditionMutator } from '../mutator/boundaryConditionMutator.js'
 import { EmptyReturnMutator } from '../mutator/emptyReturnMutator.js'
+import { EmptyStringReturnMutator } from '../mutator/emptyStringReturnMutator.js'
 import { EqualityConditionMutator } from '../mutator/equalityConditionMutator.js'
 import { FalseReturnMutator } from '../mutator/falseReturnMutator.js'
 import { IncrementMutator } from '../mutator/incrementMutator.js'
@@ -43,6 +44,7 @@ export class MutantGenerator {
     const incrementListener = new IncrementMutator()
     const boundaryListener = new BoundaryConditionMutator()
     const emptyReturnListener = new EmptyReturnMutator()
+    const emptyStringReturnListener = new EmptyStringReturnMutator()
     const trueReturnListener = new TrueReturnMutator()
     const falseReturnListener = new FalseReturnMutator()
     const nullReturnListener = new NullReturnMutator()
@@ -55,6 +57,7 @@ export class MutantGenerator {
         incrementListener,
         equalityListener,
         emptyReturnListener,
+        emptyStringReturnListener,
         trueReturnListener,
         falseReturnListener,
         nullReturnListener,

--- a/test/integration/emptyStringReturnMutator.integration.test.ts
+++ b/test/integration/emptyStringReturnMutator.integration.test.ts
@@ -1,0 +1,374 @@
+import { ParserRuleContext } from 'antlr4ts'
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { EmptyStringReturnMutator } from '../../src/mutator/emptyStringReturnMutator.js'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+import { ApexTypeResolver } from '../../src/service/apexTypeResolver.js'
+import { MutantGenerator } from '../../src/service/mutantGenerator.js'
+import { ApexMethod, ApexType } from '../../src/type/ApexMethod.js'
+
+function parseApexAndGetTypeTable(code: string): Map<string, ApexMethod> {
+  const input = new CaseInsensitiveInputStream('other', code)
+  const lexer = new ApexLexer(input)
+  const tokens = new CommonTokenStream(lexer)
+  const parser = new ApexParser(tokens)
+  const tree = parser.compilationUnit()
+
+  const resolver = new ApexTypeResolver()
+  const typeTable = resolver.analyzeMethodTypes(tree as ParserRuleContext)
+  return typeTable
+}
+
+describe('EmptyStringReturnMutator Integration', () => {
+  let mutantGenerator: MutantGenerator
+
+  beforeEach(() => {
+    mutantGenerator = new MutantGenerator()
+  })
+
+  describe('when mutating String return statements', () => {
+    it('should create mutations for String literal return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static String getName() {
+              return 'John Doe';
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getName', {
+        returnType: 'String',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.STRING,
+      })
+
+      const emptyStringReturnMutator = new EmptyStringReturnMutator()
+      emptyStringReturnMutator.setTypeTable(typeTable)
+      emptyStringReturnMutator['currentMethodName'] = 'getName'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyStringReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyStringMutations = mutations.filter(
+        m => m.mutationName === 'EmptyStringReturnMutator'
+      )
+      expect(emptyStringMutations.length).toBeGreaterThan(0)
+
+      if (emptyStringMutations.length > 0) {
+        expect(emptyStringMutations[0].replacement).toBe("''")
+
+        // Test actual mutation
+        const result = mutantGenerator.mutate(emptyStringMutations[0])
+        expect(result).toContain("return '';")
+        expect(result).not.toContain("return 'John Doe';")
+      }
+    })
+
+    it('should create mutations for String variable return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static String getMessage() {
+              String msg = 'Hello World';
+              return msg;
+            }
+          }
+        `
+      const coveredLines = new Set([5])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getMessage', {
+        returnType: 'String',
+        startLine: 3,
+        endLine: 6,
+        type: ApexType.STRING,
+      })
+
+      const emptyStringReturnMutator = new EmptyStringReturnMutator()
+      emptyStringReturnMutator.setTypeTable(typeTable)
+      emptyStringReturnMutator['currentMethodName'] = 'getMessage'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyStringReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyStringMutations = mutations.filter(
+        m => m.mutationName === 'EmptyStringReturnMutator'
+      )
+      expect(emptyStringMutations.length).toBeGreaterThan(0)
+
+      if (emptyStringMutations.length > 0) {
+        expect(emptyStringMutations[0].replacement).toBe("''")
+
+        const result = mutantGenerator.mutate(emptyStringMutations[0])
+        expect(result).toContain("return '';")
+        expect(result).not.toContain('return msg;')
+      }
+    })
+
+    it('should create mutations for String concatenation return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static String getFullName(String first, String last) {
+              return first + ' ' + last;
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getFullName', {
+        returnType: 'String',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.STRING,
+      })
+
+      const emptyStringReturnMutator = new EmptyStringReturnMutator()
+      emptyStringReturnMutator.setTypeTable(typeTable)
+      emptyStringReturnMutator['currentMethodName'] = 'getFullName'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyStringReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyStringMutations = mutations.filter(
+        m => m.mutationName === 'EmptyStringReturnMutator'
+      )
+      expect(emptyStringMutations.length).toBeGreaterThan(0)
+
+      if (emptyStringMutations.length > 0) {
+        expect(emptyStringMutations[0].replacement).toBe("''")
+
+        const result = mutantGenerator.mutate(emptyStringMutations[0])
+        expect(result).toContain("return '';")
+      }
+    })
+  })
+
+  describe('when handling non-String return types', () => {
+    it('should not create mutations for Integer return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Integer getCount() {
+              return 42;
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getCount', {
+        returnType: 'Integer',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.INTEGER,
+      })
+
+      const emptyStringReturnMutator = new EmptyStringReturnMutator()
+      emptyStringReturnMutator.setTypeTable(typeTable)
+      emptyStringReturnMutator['currentMethodName'] = 'getCount'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyStringReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyStringMutations = mutations.filter(
+        m => m.mutationName === 'EmptyStringReturnMutator'
+      )
+      expect(emptyStringMutations.length).toBe(0)
+    })
+
+    it('should not create mutations for Object return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Account getAccount() {
+              return new Account(Name = 'Test');
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getAccount', {
+        returnType: 'Account',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.OBJECT,
+      })
+
+      const emptyStringReturnMutator = new EmptyStringReturnMutator()
+      emptyStringReturnMutator.setTypeTable(typeTable)
+      emptyStringReturnMutator['currentMethodName'] = 'getAccount'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyStringReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyStringMutations = mutations.filter(
+        m => m.mutationName === 'EmptyStringReturnMutator'
+      )
+      expect(emptyStringMutations.length).toBe(0)
+    })
+  })
+
+  describe('when handling already empty string returns', () => {
+    it('should not create mutations for already empty string returns', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static String getEmpty() {
+              return '';
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getEmpty', {
+        returnType: 'String',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.STRING,
+      })
+
+      const emptyStringReturnMutator = new EmptyStringReturnMutator()
+      emptyStringReturnMutator.setTypeTable(typeTable)
+      emptyStringReturnMutator['currentMethodName'] = 'getEmpty'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyStringReturnMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyStringMutations = mutations.filter(
+        m => m.mutationName === 'EmptyStringReturnMutator'
+      )
+      expect(emptyStringMutations.length).toBe(0)
+    })
+  })
+})

--- a/test/unit/mutator/emptyStringReturnMutator.test.ts
+++ b/test/unit/mutator/emptyStringReturnMutator.test.ts
@@ -1,0 +1,322 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { EmptyStringReturnMutator } from '../../../src/mutator/emptyStringReturnMutator.js'
+import { ApexMethod, ApexType } from '../../../src/type/ApexMethod.js'
+import { TestUtil } from '../../utils/testUtil.js'
+
+describe('EmptyStringReturnMutator', () => {
+  let sut: EmptyStringReturnMutator
+
+  beforeEach(() => {
+    sut = new EmptyStringReturnMutator()
+  })
+
+  describe('Given a return statement in a method returning String', () => {
+    describe('When entering the return statement', () => {
+      it('Then should create mutation to return empty string', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'String',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'String',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.STRING,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement("'hello world'")
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe("''")
+        expect(sut._mutations[0].mutationName).toBe('EmptyStringReturnMutator')
+      })
+    })
+  })
+
+  describe('Given a return statement with a String variable', () => {
+    describe('When entering the return statement', () => {
+      it('Then should create mutation to return empty string', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'String',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'String',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.STRING,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('myStringVar')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe("''")
+      })
+    })
+  })
+
+  describe('Given a return statement already returning empty string', () => {
+    describe('When entering the return statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'String',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'String',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.STRING,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement("''")
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement in a method returning Integer', () => {
+    describe('When entering the return statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Integer',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Integer',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.INTEGER,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('42')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement in a method returning Boolean', () => {
+    describe('When entering the return statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Boolean',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Boolean',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.BOOLEAN,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('true')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement without type information', () => {
+    describe('When entering the return statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const returnCtx = TestUtil.createReturnStatement("'test'")
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('validation and edge cases', () => {
+    it('should handle return statement with no children', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration('String', 'testMethod')
+      sut.enterMethodDeclaration(methodCtx)
+
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'String',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.STRING,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = {
+        children: null,
+        childCount: 0,
+      } as unknown as ParserRuleContext
+
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+
+    it('should handle return statement with insufficient children', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration('String', 'testMethod')
+      sut.enterMethodDeclaration(methodCtx)
+
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'String',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.STRING,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = {
+        children: [{ text: 'return' }],
+        childCount: 1,
+      } as unknown as ParserRuleContext
+
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+
+    it('should handle non-ParserRuleContext expression node', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration('String', 'testMethod')
+      sut.enterMethodDeclaration(methodCtx)
+
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'String',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.STRING,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = {
+        children: [
+          { text: 'return' },
+          { text: "'hello'" }, // Not a ParserRuleContext
+        ],
+        childCount: 2,
+        getChild: (i: number) =>
+          i === 0 ? { text: 'return' } : { text: "'hello'" },
+      } as unknown as ParserRuleContext
+
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+
+    it('should handle missing method context', () => {
+      // Arrange
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'String',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.STRING,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = TestUtil.createReturnStatement("'hello'")
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+  })
+
+  describe('method tracking', () => {
+    it('should set currentMethodName on enter', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration('String', 'testMethod')
+
+      // Act
+      sut.enterMethodDeclaration(methodCtx)
+
+      // Assert
+      expect(sut['currentMethodName']).toBe('testMethod')
+    })
+
+    it('should clear currentMethodName on exit', () => {
+      // Arrange
+      sut['currentMethodName'] = 'testMethod'
+
+      // Act
+      sut.exitMethodDeclaration()
+
+      // Assert
+      expect(sut['currentMethodName']).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implements EmptyStringReturnMutator as part of the Defaults Mutator (#40)
- Mutates return statements in String methods to return `''` (empty string)
- Extends ReturnTypeAwareBaseListener for type-aware mutations

## Changes
- Add `src/mutator/emptyStringReturnMutator.ts` - new mutator implementation
- Register EmptyStringReturnMutator in `mutantGenerator.ts`
- Add unit tests covering String types and edge cases
- Add integration tests verifying actual code mutation

## Test plan
- [x] Unit tests pass for String return types
- [x] Skips mutation when already returning empty string `''`
- [x] Does not create mutations for non-String types (Integer, Boolean, Object)
- [x] Integration tests verify actual mutation output
- [x] All existing tests continue to pass

Closes #40 (partial - EmptyStringReturnMutator component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)