### PR TITLE
feat: add EmptyCollectionReturnMutator for collection return types

### DIFF
--- a/src/mutator/emptyCollectionReturnMutator.ts
+++ b/src/mutator/emptyCollectionReturnMutator.ts
@@ -1,0 +1,47 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { ApexType } from '../type/ApexMethod.js'
+import { ReturnTypeAwareBaseListener } from './returnTypeAwareBaseListener.js'
+
+export class EmptyCollectionReturnMutator extends ReturnTypeAwareBaseListener {
+  private readonly COLLECTION_TYPES = new Set([
+    ApexType.LIST,
+    ApexType.SET,
+    ApexType.MAP,
+  ])
+
+  enterReturnStatement(ctx: ParserRuleContext): void {
+    if (!this.isCurrentMethodTypeKnown()) {
+      return
+    }
+
+    const typeInfo = this.getCurrentMethodReturnTypeInfo()
+    if (!typeInfo) {
+      return
+    }
+
+    if (!this.COLLECTION_TYPES.has(typeInfo.type)) {
+      return
+    }
+
+    if (!ctx.children || ctx.children.length < 2) {
+      return
+    }
+
+    const expressionNode = ctx.children[1]
+    if (!(expressionNode instanceof ParserRuleContext)) {
+      return
+    }
+
+    const emptyCollection = `new ${typeInfo.returnType}()`
+
+    // Skip if already returning empty collection
+    if (
+      expressionNode.text.replace(/\s+/g, '') ===
+      emptyCollection.replace(/\s+/g, '')
+    ) {
+      return
+    }
+
+    this.createMutationFromParserRuleContext(expressionNode, emptyCollection)
+  }
+}

--- a/src/service/mutantGenerator.ts
+++ b/src/service/mutantGenerator.ts
@@ -9,6 +9,7 @@ import {
 } from 'apex-parser'
 import { ArithmeticOperatorMutator } from '../mutator/arithmeticOperatorMutator.js'
 import { BoundaryConditionMutator } from '../mutator/boundaryConditionMutator.js'
+import { EmptyCollectionReturnMutator } from '../mutator/emptyCollectionReturnMutator.js'
 import { EmptyReturnMutator } from '../mutator/emptyReturnMutator.js'
 import { EqualityConditionMutator } from '../mutator/equalityConditionMutator.js'
 import { FalseReturnMutator } from '../mutator/falseReturnMutator.js'
@@ -43,6 +44,7 @@ export class MutantGenerator {
     const incrementListener = new IncrementMutator()
     const boundaryListener = new BoundaryConditionMutator()
     const emptyReturnListener = new EmptyReturnMutator()
+    const emptyCollectionReturnListener = new EmptyCollectionReturnMutator()
     const trueReturnListener = new TrueReturnMutator()
     const falseReturnListener = new FalseReturnMutator()
     const nullReturnListener = new NullReturnMutator()
@@ -55,6 +57,7 @@ export class MutantGenerator {
         incrementListener,
         equalityListener,
         emptyReturnListener,
+        emptyCollectionReturnListener,
         trueReturnListener,
         falseReturnListener,
         nullReturnListener,

--- a/test/integration/emptyCollectionReturnMutator.integration.test.ts
+++ b/test/integration/emptyCollectionReturnMutator.integration.test.ts
@@ -1,0 +1,448 @@
+import { ParserRuleContext } from 'antlr4ts'
+import {
+  ApexLexer,
+  ApexParser,
+  ApexParserListener,
+  CaseInsensitiveInputStream,
+  CommonTokenStream,
+  ParseTreeWalker,
+} from 'apex-parser'
+import { EmptyCollectionReturnMutator } from '../../src/mutator/emptyCollectionReturnMutator.js'
+import { MutationListener } from '../../src/mutator/mutationListener.js'
+import { ApexTypeResolver } from '../../src/service/apexTypeResolver.js'
+import { MutantGenerator } from '../../src/service/mutantGenerator.js'
+import { ApexMethod, ApexType } from '../../src/type/ApexMethod.js'
+
+function parseApexAndGetTypeTable(code: string): Map<string, ApexMethod> {
+  const input = new CaseInsensitiveInputStream('other', code)
+  const lexer = new ApexLexer(input)
+  const tokens = new CommonTokenStream(lexer)
+  const parser = new ApexParser(tokens)
+  const tree = parser.compilationUnit()
+
+  const resolver = new ApexTypeResolver()
+  const typeTable = resolver.analyzeMethodTypes(tree as ParserRuleContext)
+  return typeTable
+}
+
+describe('EmptyCollectionReturnMutator Integration', () => {
+  let mutantGenerator: MutantGenerator
+
+  beforeEach(() => {
+    mutantGenerator = new MutantGenerator()
+  })
+
+  describe('when mutating List return statements', () => {
+    it('should create mutations for List return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static List<Account> getAccounts() {
+              return [SELECT Id FROM Account];
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getAccounts', {
+        returnType: 'List<Account>',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.LIST,
+      })
+
+      const emptyCollectionMutator = new EmptyCollectionReturnMutator()
+      emptyCollectionMutator.setTypeTable(typeTable)
+      emptyCollectionMutator['currentMethodName'] = 'getAccounts'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyCollectionMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyCollectionMutations = mutations.filter(
+        m => m.mutationName === 'EmptyCollectionReturnMutator'
+      )
+      expect(emptyCollectionMutations.length).toBeGreaterThan(0)
+
+      if (emptyCollectionMutations.length > 0) {
+        expect(emptyCollectionMutations[0].replacement).toBe(
+          'new List<Account>()'
+        )
+
+        // Test actual mutation
+        const result = mutantGenerator.mutate(emptyCollectionMutations[0])
+        expect(result).toContain('return new List<Account>();')
+        expect(result).not.toContain('return [SELECT')
+      }
+    })
+
+    it('should create mutations for List variable return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static List<String> getNames() {
+              List<String> names = new List<String>{'John', 'Jane'};
+              return names;
+            }
+          }
+        `
+      const coveredLines = new Set([5])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getNames', {
+        returnType: 'List<String>',
+        startLine: 3,
+        endLine: 6,
+        type: ApexType.LIST,
+      })
+
+      const emptyCollectionMutator = new EmptyCollectionReturnMutator()
+      emptyCollectionMutator.setTypeTable(typeTable)
+      emptyCollectionMutator['currentMethodName'] = 'getNames'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyCollectionMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyCollectionMutations = mutations.filter(
+        m => m.mutationName === 'EmptyCollectionReturnMutator'
+      )
+      expect(emptyCollectionMutations.length).toBeGreaterThan(0)
+
+      if (emptyCollectionMutations.length > 0) {
+        expect(emptyCollectionMutations[0].replacement).toBe(
+          'new List<String>()'
+        )
+
+        const result = mutantGenerator.mutate(emptyCollectionMutations[0])
+        expect(result).toContain('return new List<String>();')
+        expect(result).not.toContain('return names;')
+      }
+    })
+  })
+
+  describe('when mutating Set return statements', () => {
+    it('should create mutations for Set return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Set<Id> getIds() {
+              Set<Id> ids = new Set<Id>();
+              ids.add('001000000000001');
+              return ids;
+            }
+          }
+        `
+      const coveredLines = new Set([6])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getIds', {
+        returnType: 'Set<Id>',
+        startLine: 3,
+        endLine: 7,
+        type: ApexType.SET,
+      })
+
+      const emptyCollectionMutator = new EmptyCollectionReturnMutator()
+      emptyCollectionMutator.setTypeTable(typeTable)
+      emptyCollectionMutator['currentMethodName'] = 'getIds'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyCollectionMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyCollectionMutations = mutations.filter(
+        m => m.mutationName === 'EmptyCollectionReturnMutator'
+      )
+      expect(emptyCollectionMutations.length).toBeGreaterThan(0)
+
+      if (emptyCollectionMutations.length > 0) {
+        expect(emptyCollectionMutations[0].replacement).toBe('new Set<Id>()')
+
+        const result = mutantGenerator.mutate(emptyCollectionMutations[0])
+        expect(result).toContain('return new Set<Id>();')
+        expect(result).not.toContain('return ids;')
+      }
+    })
+  })
+
+  describe('when mutating Map return statements', () => {
+    it('should create mutations for Map return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Map<Id, Account> getAccountMap() {
+              Map<Id, Account> accountMap = new Map<Id, Account>();
+              return accountMap;
+            }
+          }
+        `
+      const coveredLines = new Set([5])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+      mutantGenerator['tokenStream'] = tokens
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getAccountMap', {
+        returnType: 'Map<Id, Account>',
+        startLine: 3,
+        endLine: 6,
+        type: ApexType.MAP,
+      })
+
+      const emptyCollectionMutator = new EmptyCollectionReturnMutator()
+      emptyCollectionMutator.setTypeTable(typeTable)
+      emptyCollectionMutator['currentMethodName'] = 'getAccountMap'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyCollectionMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyCollectionMutations = mutations.filter(
+        m => m.mutationName === 'EmptyCollectionReturnMutator'
+      )
+      expect(emptyCollectionMutations.length).toBeGreaterThan(0)
+
+      if (emptyCollectionMutations.length > 0) {
+        expect(emptyCollectionMutations[0].replacement).toBe(
+          'new Map<Id, Account>()'
+        )
+
+        const result = mutantGenerator.mutate(emptyCollectionMutations[0])
+        expect(result).toContain('return new Map<Id, Account>();')
+        expect(result).not.toContain('return accountMap;')
+      }
+    })
+  })
+
+  describe('when handling non-collection return types', () => {
+    it('should not create mutations for String return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static String getName() {
+              return 'test';
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getName', {
+        returnType: 'String',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.STRING,
+      })
+
+      const emptyCollectionMutator = new EmptyCollectionReturnMutator()
+      emptyCollectionMutator.setTypeTable(typeTable)
+      emptyCollectionMutator['currentMethodName'] = 'getName'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyCollectionMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyCollectionMutations = mutations.filter(
+        m => m.mutationName === 'EmptyCollectionReturnMutator'
+      )
+      expect(emptyCollectionMutations.length).toBe(0)
+    })
+
+    it('should not create mutations for Object return values', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static Account getAccount() {
+              return new Account(Name = 'Test');
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getAccount', {
+        returnType: 'Account',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.OBJECT,
+      })
+
+      const emptyCollectionMutator = new EmptyCollectionReturnMutator()
+      emptyCollectionMutator.setTypeTable(typeTable)
+      emptyCollectionMutator['currentMethodName'] = 'getAccount'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyCollectionMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyCollectionMutations = mutations.filter(
+        m => m.mutationName === 'EmptyCollectionReturnMutator'
+      )
+      expect(emptyCollectionMutations.length).toBe(0)
+    })
+  })
+
+  describe('when handling already empty collection returns', () => {
+    it('should not create mutations for already empty List returns', () => {
+      // Arrange
+      const classContent = `
+          public class TestClass {
+            public static List<String> getEmpty() {
+              return new List<String>();
+            }
+          }
+        `
+      const coveredLines = new Set([4])
+
+      const lexer = new ApexLexer(
+        new CaseInsensitiveInputStream('other', classContent)
+      )
+      const tokens = new CommonTokenStream(lexer)
+
+      const typeTable = parseApexAndGetTypeTable(classContent)
+      typeTable.set('getEmpty', {
+        returnType: 'List<String>',
+        startLine: 3,
+        endLine: 5,
+        type: ApexType.LIST,
+      })
+
+      const emptyCollectionMutator = new EmptyCollectionReturnMutator()
+      emptyCollectionMutator.setTypeTable(typeTable)
+      emptyCollectionMutator['currentMethodName'] = 'getEmpty'
+
+      const parser = new ApexParser(tokens)
+      const tree = parser.compilationUnit()
+
+      const listener = new MutationListener(
+        [emptyCollectionMutator],
+        coveredLines,
+        typeTable
+      )
+
+      ParseTreeWalker.DEFAULT.walk(
+        listener as ApexParserListener,
+        tree as ParserRuleContext
+      )
+
+      const mutations = listener.getMutations()
+
+      // Assert
+      const emptyCollectionMutations = mutations.filter(
+        m => m.mutationName === 'EmptyCollectionReturnMutator'
+      )
+      expect(emptyCollectionMutations.length).toBe(0)
+    })
+  })
+})

--- a/test/unit/mutator/emptyCollectionReturnMutator.test.ts
+++ b/test/unit/mutator/emptyCollectionReturnMutator.test.ts
@@ -1,0 +1,455 @@
+import { ParserRuleContext } from 'antlr4ts'
+import { EmptyCollectionReturnMutator } from '../../../src/mutator/emptyCollectionReturnMutator.js'
+import { ApexMethod, ApexType } from '../../../src/type/ApexMethod.js'
+import { TestUtil } from '../../utils/testUtil.js'
+
+describe('EmptyCollectionReturnMutator', () => {
+  let sut: EmptyCollectionReturnMutator
+
+  beforeEach(() => {
+    sut = new EmptyCollectionReturnMutator()
+  })
+
+  describe('Given a return statement in a method returning List', () => {
+    describe('When entering the return statement', () => {
+      it('Then should create mutation to return empty List', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'List<Account>',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'List<Account>',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.LIST,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('accounts')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('new List<Account>()')
+        expect(sut._mutations[0].mutationName).toBe(
+          'EmptyCollectionReturnMutator'
+        )
+      })
+    })
+  })
+
+  describe('Given a return statement in a method returning Set', () => {
+    describe('When entering the return statement', () => {
+      it('Then should create mutation to return empty Set', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Set<Id>',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Set<Id>',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.SET,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('idSet')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('new Set<Id>()')
+      })
+    })
+  })
+
+  describe('Given a return statement in a method returning Map', () => {
+    describe('When entering the return statement', () => {
+      it('Then should create mutation to return empty Map', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Map<Id,Account>',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Map<Id,Account>',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.MAP,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('accountMap')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('new Map<Id,Account>()')
+      })
+    })
+  })
+
+  describe('Given a return statement already returning empty collection', () => {
+    describe('When returning new List<T>()', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'List<String>',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'List<String>',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.LIST,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('new List<String>()')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+
+    describe('When returning new Set<T>()', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Set<Id>',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Set<Id>',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.SET,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('new Set<Id>()')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+
+    describe('When returning new Map<K,V>()', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Map<Id,Account>',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Map<Id,Account>',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.MAP,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement(
+          'new Map<Id,Account>()'
+        )
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement in a method returning non-collection type', () => {
+    describe('When returning String', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'String',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'String',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.STRING,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement("'hello'")
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+
+    describe('When returning Integer', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Integer',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Integer',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.INTEGER,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('42')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+
+    describe('When returning Object', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const methodCtx = TestUtil.createMethodDeclaration(
+          'Account',
+          'testMethod'
+        )
+        sut.enterMethodDeclaration(methodCtx)
+
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Account',
+          startLine: 1,
+          endLine: 10,
+          type: ApexType.OBJECT,
+        })
+        sut.setTypeTable(typeTable)
+
+        const returnCtx = TestUtil.createReturnStatement('acc')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('Given a return statement without type information', () => {
+    describe('When entering the return statement', () => {
+      it('Then should not create any mutations', () => {
+        // Arrange
+        const returnCtx = TestUtil.createReturnStatement('accounts')
+        sut._mutations = []
+
+        // Act
+        sut.enterReturnStatement(returnCtx)
+
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('validation and edge cases', () => {
+    it('should handle return statement with no children', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration(
+        'List<String>',
+        'testMethod'
+      )
+      sut.enterMethodDeclaration(methodCtx)
+
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'List<String>',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.LIST,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = {
+        children: null,
+        childCount: 0,
+      } as unknown as ParserRuleContext
+
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+
+    it('should handle return statement with insufficient children', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration(
+        'List<String>',
+        'testMethod'
+      )
+      sut.enterMethodDeclaration(methodCtx)
+
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'List<String>',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.LIST,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = {
+        children: [{ text: 'return' }],
+        childCount: 1,
+      } as unknown as ParserRuleContext
+
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+
+    it('should handle non-ParserRuleContext expression node', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration(
+        'List<String>',
+        'testMethod'
+      )
+      sut.enterMethodDeclaration(methodCtx)
+
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'List<String>',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.LIST,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = {
+        children: [
+          { text: 'return' },
+          { text: 'myList' }, // Not a ParserRuleContext
+        ],
+        childCount: 2,
+        getChild: (i: number) =>
+          i === 0 ? { text: 'return' } : { text: 'myList' },
+      } as unknown as ParserRuleContext
+
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+
+    it('should handle missing method context', () => {
+      // Arrange
+      const typeTable = new Map<string, ApexMethod>()
+      typeTable.set('testMethod', {
+        returnType: 'List<String>',
+        startLine: 1,
+        endLine: 10,
+        type: ApexType.LIST,
+      })
+      sut.setTypeTable(typeTable)
+
+      const returnCtx = TestUtil.createReturnStatement('myList')
+      sut._mutations = []
+
+      // Act
+      sut.enterReturnStatement(returnCtx)
+
+      // Assert
+      expect(sut._mutations).toHaveLength(0)
+    })
+  })
+
+  describe('method tracking', () => {
+    it('should set currentMethodName on enter', () => {
+      // Arrange
+      const methodCtx = TestUtil.createMethodDeclaration(
+        'List<String>',
+        'testMethod'
+      )
+
+      // Act
+      sut.enterMethodDeclaration(methodCtx)
+
+      // Assert
+      expect(sut['currentMethodName']).toBe('testMethod')
+    })
+
+    it('should clear currentMethodName on exit', () => {
+      // Arrange
+      sut['currentMethodName'] = 'testMethod'
+
+      // Act
+      sut.exitMethodDeclaration()
+
+      // Assert
+      expect(sut['currentMethodName']).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implements EmptyCollectionReturnMutator as part of the Defaults Mutator (#40)
- Mutates return statements in collection methods to return empty collections
- Supports List<T>, Set<T>, and Map<K,V> return types
- Extends ReturnTypeAwareBaseListener for type-aware mutations

## Changes
- Add `src/mutator/emptyCollectionReturnMutator.ts` - new mutator implementation
- Register EmptyCollectionReturnMutator in `mutantGenerator.ts`
- Add unit tests covering List, Set, Map types and edge cases
- Add integration tests verifying actual code mutation

## Examples
| Original | Mutated |
|----------|---------|
| `return accounts;` | `return new List<Account>();` |
| `return idSet;` | `return new Set<Id>();` |
| `return accountMap;` | `return new Map<Id,Account>();` |

## Test plan
- [x] Unit tests pass for List, Set, and Map return types
- [x] Skips mutation when already returning empty collection
- [x] Does not create mutations for non-collection types (String, Integer, Object)
- [x] Integration tests verify actual mutation output
- [x] All existing tests continue to pass

Closes #40 (partial - EmptyCollectionReturnMutator component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)