### PR TITLE
chore: upgrade node engine floor to 22 with 22/24/26 support

### DIFF
--- a/.github/workflows/npm-service.yml
+++ b/.github/workflows/npm-service.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
           registry-url: "https://registry.npmjs.org"
       - run: npm install -g npm@latest
       - uses: ./.github/actions/install
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
       - uses: ./.github/actions/install
 
       - name: Build and pack

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
 
       - name: Setup dependencies, cache and install
         uses: ./.github/actions/install
@@ -58,7 +58,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
 
       - name: Setup dependencies, cache and install
         uses: ./.github/actions/install
@@ -71,6 +71,9 @@ jobs:
 
       - name: Audit dependencies
         run: npm audit --audit-level=high
+
+      - name: Check engines
+        run: npm run lint:engine
 
   megalinter:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   source:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24, 26]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -13,9 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
-
-      - uses: google/wireit@setup-github-actions-caching/v2
+          node-version: ${{ matrix.node }}
 
       - name: Setup dependencies, cache and install
         uses: ./.github/actions/install
@@ -34,5 +36,5 @@ jobs:
 
       - uses: actions/upload-artifact@v6
         with:
-          name: coverage-test-report
+          name: coverage-test-report-${{ matrix.node }}
           path: reports/coverage

--- a/.github/workflows/reusable-perf.yml
+++ b/.github/workflows/reusable-perf.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
 
       - uses: google/wireit@setup-github-actions-caching/v2
 

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
 
       - name: Set environment variables
         run: |

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,3 +3,4 @@ npm run test
 npm outdated || true
 npm audit || true
 npm run lint:dependencies || true
+npm run lint:engine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We encourage the developer community to contribute to this repository. This guid
 
 ## Requirements
 
-- [Node](https://nodejs.org/) >= 18.6.0
+- [Node](https://nodejs.org/) >= 22.22 (supported: 22, 24, 26)
 - [npm](https://www.npmjs.com/) >= 10.9.0
 
 ## Installation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,11 @@ You can use an interactive command line to help you create supported commit mess
 npm run commit
 ```
 
+### Engine linting
+
+This repository uses [ls-engines](https://github.com/ljharb/ls-engines) to verify the running Node version is within the supported range and that `engines.node` stays consistent with the dependency graph.
+It runs as a blocking pre-push git hook and as a pull request check.
+
 ### PR linting
 
 When a PR is ready for merge we use the PR name to create the squash and merge commit message.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,6 +12,8 @@ sf apex mutation test run -c <ApexClass> -t <TestClass> -o <TargetOrg> --skip-pa
 sf apex mutation test run -c <ApexClass> -t <TestClass> -o <TargetOrg> --config-file .mutation-testing.json
 ```
 
+**Runtime:** requires Node 22, 24, or 26 (`engines.node` = `^22.22 || ^24.15 || >=26`).
+
 ---
 
 ## Architecture Layers

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "husky": "^9.1.7",
         "knip": "^6.26.0",
+        "ls-engines": "^0.10.1",
         "oclif": "^4.23.27",
         "shx": "^0.4.0",
         "tslib": "^2.8.1",
@@ -1153,6 +1154,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
@@ -1493,6 +1504,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1724,6 +1742,549 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+      "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/arborist": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.9.0.tgz",
+      "integrity": "sha512-tzsb1R8mx0k0drlLDT/9ckEYaQHIaWnUti/ci2IaFoQqdqwfmYrc+90p1+QEZC/ocvqcxBep9P1xKw4FbAGofw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@isaacs/string-locale-compare": "^1.1.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/metavuln-calculator": "^9.0.2",
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/query": "^5.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "bin-links": "^6.0.0",
+        "cacache": "^20.0.1",
+        "common-ancestor-path": "^2.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-stringify-nice": "^1.1.4",
+        "lru-cache": "^11.2.1",
+        "minimatch": "^10.0.3",
+        "nopt": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "pacote": "^21.0.2",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.0.0",
+        "proggy": "^4.0.0",
+        "promise-all-reject-late": "^1.0.0",
+        "promise-call-limit": "^3.0.1",
+        "semver": "^7.3.7",
+        "ssri": "^13.0.0",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^4.0.0"
+      },
+      "bin": {
+        "arborist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/arborist/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+      "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
+        "lru-cache": "^11.2.1",
+        "npm-pick-manifest": "^11.0.1",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/installed-package-contents": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+      "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "bin": {
+        "installed-package-contents": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
+      "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "glob": "^13.0.0",
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/metavuln-calculator": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
+      "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cacache": "^20.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "pacote": "^21.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/metavuln-calculator/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/name-from-folder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
+      "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/node-gyp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
+      "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+      "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^7.0.0",
+        "glob": "^13.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.5.3",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+      "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
+      "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/run-script": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
+      "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "node-gyp": "^12.1.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/run-script/node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/run-script/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@npmcli/run-script/node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/run-script/node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/run-script/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/run-script/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@npmcli/run-script/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@oclif/core": {
@@ -3422,6 +3983,96 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
     },
+    "node_modules/@sigstore/bundle": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
+      "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/core": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/protobuf-specs": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
+      "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@sigstore/sign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+      "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/sign/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/tuf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+      "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "tuf-js": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@sigstore/verify": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.1.tgz",
+      "integrity": "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@simple-libs/stream-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
@@ -3702,6 +4353,30 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/@tufjs/canonical-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@tufjs/models": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
+      "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -4326,6 +5001,16 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -4458,6 +5143,64 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -4493,11 +5236,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
@@ -4534,6 +5297,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -4584,6 +5363,33 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bin-links": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.2.tgz",
+      "integrity": "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/bin-links/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -4693,6 +5499,38 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -4733,6 +5571,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -4995,6 +5852,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/code-excerpt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -5050,6 +5917,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/concat-map": {
@@ -5167,6 +6044,19 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -5184,6 +6074,60 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.1.tgz",
       "integrity": "sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==",
       "license": "MIT"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/dateformat": {
       "version": "4.6.3",
@@ -5248,6 +6192,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -5385,6 +6365,94 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -5435,6 +6503,40 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
@@ -5527,6 +6629,13 @@
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/fast_array_intersect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast_array_intersect/-/fast_array_intersect-1.1.0.tgz",
+      "integrity": "sha512-/DCilZlUdz2XyNDF+ASs0PwY+RKG9Y4Silp/gbS72Cvbg4oibc778xcecg+pnNyiNHYgh/TApsiDTjpdniyShw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-copy": {
       "version": "3.0.2",
@@ -5758,6 +6867,22 @@
         "micromatch": "^4.0.2"
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -5815,6 +6940,19 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5839,6 +6977,50 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5846,6 +7028,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-dep-tree": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-dep-tree/-/get-dep-tree-3.0.0.tgz",
+      "integrity": "sha512-1Z8Bh5lIQdCuyQLyx20+8UD8Kg4Q/eKADW6kTUCXug0yRUEPq6nMajmo1vn1PZGGekicgBXPZr9tY/pfW839fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@npmcli/arborist": "^9.1.9",
+        "array.prototype.flat": "^1.3.3",
+        "lockfile-info": "^1.1.0",
+        "pacote": "^21.0.4"
+      },
+      "engines": {
+        "node": "^22.21 || ^24.12 || >= 25.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -5882,6 +7083,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-json/-/get-json-1.1.0.tgz",
+      "integrity": "sha512-IjoEwpXyyEsRtwBSZ0SYA6By6oVBnakpftFHAAkSSlLYRZ1NPGFS/r+6fSgbk7t6njfEuYVMbD1pe4ex6vgLcw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "jsonp": "^0.2.1",
+        "safe-buffer": "^5.2.1",
+        "safe-regex-test": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-package-type": {
@@ -5922,6 +7138,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -5941,6 +7175,24 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -5968,6 +7220,23 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gopd": {
@@ -6040,6 +7309,19 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6047,6 +7329,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -6174,6 +7485,20 @@
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -6186,6 +7511,20 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -6257,6 +7596,19 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore-walk": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+      "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/immediate": {
       "version": "3.0.6",
@@ -6477,6 +7829,21 @@
         "url": "https://github.com/sponsors/uhop"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -6487,12 +7854,86 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.2.tgz",
+      "integrity": "sha512-a2xr4E3s1PjDS8ORcGgXpWx6V+liNs+O3JRD2mb9aeugD7rtkkZ0zgLdYgw0tWsKhsdiezGYptSiMlVazCBTuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -6507,6 +7948,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
@@ -6515,6 +7986,41 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6538,6 +8044,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6545,6 +8067,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -6557,6 +8095,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -6586,6 +8144,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6593,6 +8177,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-plain-obj": {
@@ -6607,6 +8208,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-retry-allowed": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
@@ -6615,6 +8235,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -6629,6 +8278,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -6639,6 +8339,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -6789,12 +8535,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-file-plus": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/json-file-plus/-/json-file-plus-4.0.1.tgz",
+      "integrity": "sha512-3ZDj5pi7HCaFRpJ91LHoYfEdBkyzQijAWDE15W09dw/kwLF8Nz8zVIeSMYpetPHtgeQPE2swz7z6MGq6Ce0OWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node.extend": "^2.0.3"
+      },
+      "engines": {
+        "node": "^16.20.2 || ^18.20.6 || ^20.18.3 || ^22.14.0 || >= 23.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+      "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/json-rpc-2.0": {
       "version": "1.7.1",
@@ -6815,6 +8587,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=7.10.1"
+      }
+    },
+    "node_modules/json-stringify-nice": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
+      "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
+      "dev": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/json5": {
@@ -6845,6 +8627,42 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3"
+      }
+    },
+    "node_modules/jsonp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/jsonp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -6879,6 +8697,20 @@
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
       }
+    },
+    "node_modules/just-diff": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
+      "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/just-diff-apply": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
+      "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -7244,6 +9076,23 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/lockfile-info": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lockfile-info/-/lockfile-info-1.1.0.tgz",
+      "integrity": "sha512-JG0/EwBh6AmfakC+fbEV+5gPUVZVB1kmdnbcJ5wllEbiuKc7ULcXyGi6o0q4JHQjKIg6YM3x82VZ4hoFA6tzkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -7298,6 +9147,13 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7341,6 +9197,29 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/ls-engines": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ls-engines/-/ls-engines-0.10.1.tgz",
+      "integrity": "sha512-ZFTbaq3U9ApZQJKDcEHn00T3lESwIBOmXnGrm810u+inGwHXzCxlHTArC8UPhi1dGjARIyJvLNGyPJoQvkHVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast_array_intersect": "^1.1.0",
+        "get-dep-tree": "^3.0.0",
+        "get-json": "^1.1.0",
+        "json-file-plus": "^4.0.1",
+        "pargs": "^1.4.2",
+        "semver": "^7.8.5",
+        "table": "^6.9.0"
+      },
+      "bin": {
+        "ls-engines": "bin.mjs"
+      },
+      "engines": {
+        "node": "^22.21 || ^24.12 || >= 25.2",
+        "npm": ">=8"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7376,6 +9255,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "15.0.6",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+      "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7524,6 +9437,116 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/minizlib": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
@@ -7642,6 +9665,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -7756,6 +9789,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/node.extend": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.3.tgz",
+      "integrity": "sha512-xwADg/okH48PvBmRZyoX8i8GJaKuJ1CqlqotlZOhUio8egD1P5trJupHKBzcPjSF9ifK2gPcEICRBnkfPqQXZw==",
+      "dev": true,
+      "license": "(MIT OR GPL-2.0)",
+      "dependencies": {
+        "hasown": "^2.0.0",
+        "is": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-10.0.1.tgz",
@@ -7809,6 +9856,171 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-bundled": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+      "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-install-checks": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+      "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-packlist": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+      "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^8.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-packlist/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-pick-manifest": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+      "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-registry-fetch": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+      "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/redact": "^4.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^15.0.0",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^13.0.0",
+        "proc-log": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-registry-fetch/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -7851,6 +10063,37 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -8109,6 +10352,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/oxc-parser": {
       "version": "0.137.0",
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.137.0.tgz",
@@ -8198,6 +10459,61 @@
         "node": ">=4"
       }
     },
+    "node_modules/p-map": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pacote": {
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
+      "integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "cacache": "^20.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^13.0.0",
+        "npm-packlist": "^10.0.1",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0",
+        "tar": "^7.4.3"
+      },
+      "bin": {
+        "pacote": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/pacote/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -8212,6 +10528,34 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/pargs": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/pargs/-/pargs-1.4.2.tgz",
+      "integrity": "sha512-8PfR1ib1p8aNAC8sGCcUgLxbu78JrcbUa/tUvhtz0GMRtLbAJOR0tt3wnA1znOcsqQ+lOeuefuyzgC0i7CnwyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.20 || ^24.10 || >= 25"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/parse-conflict-json": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
+      "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^5.0.0",
+        "just-diff": "^6.0.0",
+        "just-diff-apply": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/parse-json": {
@@ -8284,6 +10628,33 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -8453,6 +10824,16 @@
         "split2": "^4.0.0"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.19",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
@@ -8480,6 +10861,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/pretty-ms": {
@@ -8537,6 +10932,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/proggy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
+      "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -8544,6 +10949,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-all-reject-late": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+      "dev": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/promise-call-limit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
+      "integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
+      "dev": true,
+      "license": "ISC",
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/proper-lockfile": {
@@ -8689,6 +11114,16 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -8755,6 +11190,50 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/registry-auth-token": {
@@ -8952,6 +11431,33 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8971,6 +11477,48 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -9041,6 +11589,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setimmediate": {
@@ -9332,6 +11929,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sigstore": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.1.tgz",
+      "integrity": "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
@@ -9346,6 +11961,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/smol-toml": {
@@ -9369,6 +11995,36 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/sonic-boom": {
@@ -9444,6 +12100,19 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -9478,6 +12147,20 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -9542,6 +12225,66 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -9645,6 +12388,90 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tar": {
@@ -9857,6 +12684,16 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/treeverse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
+      "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/ts-retry-promise": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.8.1.tgz",
@@ -9871,6 +12708,21 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tuf-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
+      "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -9903,6 +12755,84 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typed-inject": {
@@ -9973,6 +12903,25 @@
       "license": "ISC",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/underscore": {
@@ -10316,6 +13265,102 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -10432,6 +13477,19 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@oclif/core": "^4.11.14",
         "@salesforce/apex-node": "^8.4.35",
-        "@salesforce/core": "^8.32.2",
+        "@salesforce/core": "^8.32.3",
         "@salesforce/sf-plugins-core": "^12.2.26",
         "@stryker-mutator/core": "^9.6.1",
         "antlr4ts": "^0.5.0-alpha.4",
@@ -21,7 +21,7 @@
         "re2": "^1.26.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.5.3",
+        "@biomejs/biome": "^2.5.4",
         "@commitlint/config-conventional": "^21.2.0",
         "@oclif/plugin-help": "^6.2.53",
         "@salesforce/dev-config": "^4.3.3",
@@ -907,9 +907,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-      "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.4.tgz",
+      "integrity": "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -923,20 +923,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.3",
-        "@biomejs/cli-darwin-x64": "2.5.3",
-        "@biomejs/cli-linux-arm64": "2.5.3",
-        "@biomejs/cli-linux-arm64-musl": "2.5.3",
-        "@biomejs/cli-linux-x64": "2.5.3",
-        "@biomejs/cli-linux-x64-musl": "2.5.3",
-        "@biomejs/cli-win32-arm64": "2.5.3",
-        "@biomejs/cli-win32-x64": "2.5.3"
+        "@biomejs/cli-darwin-arm64": "2.5.4",
+        "@biomejs/cli-darwin-x64": "2.5.4",
+        "@biomejs/cli-linux-arm64": "2.5.4",
+        "@biomejs/cli-linux-arm64-musl": "2.5.4",
+        "@biomejs/cli-linux-x64": "2.5.4",
+        "@biomejs/cli-linux-x64-musl": "2.5.4",
+        "@biomejs/cli-win32-arm64": "2.5.4",
+        "@biomejs/cli-win32-x64": "2.5.4"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-      "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.4.tgz",
+      "integrity": "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==",
       "cpu": [
         "arm64"
       ],
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-      "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.4.tgz",
+      "integrity": "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==",
       "cpu": [
         "x64"
       ],
@@ -968,9 +968,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-      "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.4.tgz",
+      "integrity": "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==",
       "cpu": [
         "arm64"
       ],
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-      "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.4.tgz",
+      "integrity": "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==",
       "cpu": [
         "arm64"
       ],
@@ -1008,9 +1008,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-      "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.4.tgz",
+      "integrity": "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==",
       "cpu": [
         "x64"
       ],
@@ -1028,9 +1028,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-      "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.4.tgz",
+      "integrity": "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==",
       "cpu": [
         "x64"
       ],
@@ -1048,9 +1048,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-      "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.4.tgz",
+      "integrity": "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==",
       "cpu": [
         "arm64"
       ],
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-      "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.4.tgz",
+      "integrity": "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "postpack": "shx rm -f oclif.manifest.json && shx sed -i 'blob/v[^/]*/' 'blob/main/' README.md",
     "prepack": "wireit",
     "prepare": "husky",
-    "prepublishOnly": "npm shrinkwrap",
+    "prepublishOnly": "shx cp package-lock.json npm-shrinkwrap.json",
     "test:build": "wireit",
     "test:mutation": "stryker run",
     "test:nut": "wireit",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "husky": "^9.1.7",
     "knip": "^6.26.0",
+    "ls-engines": "^0.10.1",
     "oclif": "^4.23.27",
     "shx": "^0.4.0",
     "tslib": "^2.8.1",
@@ -35,7 +36,7 @@
     "qs": "^6.15.2"
   },
   "engines": {
-    "node": ">=20"
+    "node": "^22.22 || ^24.15 || >=26"
   },
   "files": [
     "/lib",
@@ -80,6 +81,7 @@
     "devops:move-tag": "./tooling/devops-movetag.sh",
     "lint": "wireit",
     "lint:dependencies": "wireit",
+    "lint:engine": "ls-engines",
     "lint:fix": "wireit",
     "lint:staged": "wireit",
     "postpack": "shx rm -f oclif.manifest.json && shx sed -i 'blob/v[^/]*/' 'blob/main/' README.md",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@oclif/core": "^4.11.14",
     "@salesforce/apex-node": "^8.4.35",
-    "@salesforce/core": "^8.32.2",
+    "@salesforce/core": "^8.32.3",
     "@salesforce/sf-plugins-core": "^12.2.26",
     "@stryker-mutator/core": "^9.6.1",
     "antlr4ts": "^0.5.0-alpha.4",
@@ -15,7 +15,7 @@
     "re2": "^1.26.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.3",
+    "@biomejs/biome": "^2.5.4",
     "@commitlint/config-conventional": "^21.2.0",
     "@oclif/plugin-help": "^6.2.53",
     "@salesforce/dev-config": "^4.3.3",

--- a/test/unit/adapter/sObjectDescribeRepository.test.ts
+++ b/test/unit/adapter/sObjectDescribeRepository.test.ts
@@ -90,20 +90,23 @@ describe('SObjectDescribeRepository', () => {
       ['email', APEX_TYPE.STRING],
       ['multipicklist', APEX_TYPE.STRING],
       ['encryptedstring', APEX_TYPE.STRING],
-    ])('Then should map describe type "%s" to %s', async (describeType, expectedApexType) => {
-      // Arrange
-      describeMock.mockResolvedValue({
-        fields: [{ name: 'TestField', type: describeType }],
-      })
+    ])(
+      'Then should map describe type "%s" to %s',
+      async (describeType, expectedApexType) => {
+        // Arrange
+        describeMock.mockResolvedValue({
+          fields: [{ name: 'TestField', type: describeType }],
+        })
 
-      // Act
-      await sut.describe(['Account'])
+        // Act
+        await sut.describe(['Account'])
 
-      // Assert
-      expect(sut.resolveFieldType('account', 'testfield')).toBe(
-        expectedApexType
-      )
-    })
+        // Assert
+        expect(sut.resolveFieldType('account', 'testfield')).toBe(
+          expectedApexType
+        )
+      }
+    )
   })
 
   describe('Given a describe call fails for one sObject', () => {

--- a/test/unit/mutator/arithmeticOperatorDeletionMutator.test.ts
+++ b/test/unit/mutator/arithmeticOperatorDeletionMutator.test.ts
@@ -739,21 +739,22 @@ describe('ArithmeticOperatorDeletionMutator', () => {
       { right: '0.0D', description: 'double zero uppercase D' },
       { right: '0.0f', description: 'float zero lowercase f' },
       { right: '0.0F', description: 'float zero uppercase F' },
-    ])('Then should NOT generate right mutation for a + $description (equivalent)', ({
-      right,
-    }) => {
-      // Arrange
-      const typeRegistry = createTypeRegistry()
-      const sut = new ArithmeticOperatorDeletionMutator(typeRegistry)
-      const ctx = createArithmeticCtxInMethod('a', '+', right, 'testMethod')
+    ])(
+      'Then should NOT generate right mutation for a + $description (equivalent)',
+      ({ right }) => {
+        // Arrange
+        const typeRegistry = createTypeRegistry()
+        const sut = new ArithmeticOperatorDeletionMutator(typeRegistry)
+        const ctx = createArithmeticCtxInMethod('a', '+', right, 'testMethod')
 
-      // Act
-      sut.enterArth2Expression(ctx as unknown as Arth2ExpressionContext)
+        // Act
+        sut.enterArth2Expression(ctx as unknown as Arth2ExpressionContext)
 
-      // Assert — right identity for + means a + 0 = a, so only left mutation (→ right) skipped
-      expect(sut._mutations).toHaveLength(1)
-      expect(sut._mutations[0].replacement).toBe(right)
-    })
+        // Assert — right identity for + means a + 0 = a, so only left mutation (→ right) skipped
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe(right)
+      }
+    )
 
     it.each([
       { right: '1L', description: 'Long one' },
@@ -764,21 +765,22 @@ describe('ArithmeticOperatorDeletionMutator', () => {
       { right: '1.0D', description: 'double one uppercase D' },
       { right: '1.0f', description: 'float one lowercase f' },
       { right: '1.0F', description: 'float one uppercase F' },
-    ])('Then should NOT generate right mutation for a * $description (equivalent)', ({
-      right,
-    }) => {
-      // Arrange
-      const typeRegistry = createTypeRegistry()
-      const sut = new ArithmeticOperatorDeletionMutator(typeRegistry)
-      const ctx = createArithmeticCtxInMethod('a', '*', right, 'testMethod')
+    ])(
+      'Then should NOT generate right mutation for a * $description (equivalent)',
+      ({ right }) => {
+        // Arrange
+        const typeRegistry = createTypeRegistry()
+        const sut = new ArithmeticOperatorDeletionMutator(typeRegistry)
+        const ctx = createArithmeticCtxInMethod('a', '*', right, 'testMethod')
 
-      // Act
-      sut.enterArth1Expression(ctx as unknown as Arth1ExpressionContext)
+        // Act
+        sut.enterArth1Expression(ctx as unknown as Arth1ExpressionContext)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(1)
-      expect(sut._mutations[0].replacement).toBe(right)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe(right)
+      }
+    )
 
     it.each([
       { left: '0L', description: 'Long zero uppercase L' },
@@ -789,21 +791,22 @@ describe('ArithmeticOperatorDeletionMutator', () => {
       { left: '0.0D', description: 'double zero uppercase D' },
       { left: '0.0f', description: 'float zero lowercase f' },
       { left: '0.0F', description: 'float zero uppercase F' },
-    ])('Then should NOT generate left mutation for $description + b (equivalent)', ({
-      left,
-    }) => {
-      // Arrange
-      const typeRegistry = createTypeRegistry()
-      const sut = new ArithmeticOperatorDeletionMutator(typeRegistry)
-      const ctx = createArithmeticCtxInMethod(left, '+', 'b', 'testMethod')
+    ])(
+      'Then should NOT generate left mutation for $description + b (equivalent)',
+      ({ left }) => {
+        // Arrange
+        const typeRegistry = createTypeRegistry()
+        const sut = new ArithmeticOperatorDeletionMutator(typeRegistry)
+        const ctx = createArithmeticCtxInMethod(left, '+', 'b', 'testMethod')
 
-      // Act
-      sut.enterArth2Expression(ctx as unknown as Arth2ExpressionContext)
+        // Act
+        sut.enterArth2Expression(ctx as unknown as Arth2ExpressionContext)
 
-      // Assert — left identity for + means 0 + b = b
-      expect(sut._mutations).toHaveLength(1)
-      expect(sut._mutations[0].replacement).toBe(left)
-    })
+        // Assert — left identity for + means 0 + b = b
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe(left)
+      }
+    )
 
     it.each([
       { left: '1L', description: 'Long one uppercase L' },
@@ -814,21 +817,22 @@ describe('ArithmeticOperatorDeletionMutator', () => {
       { left: '1.0D', description: 'double one uppercase D' },
       { left: '1.0f', description: 'float one lowercase f' },
       { left: '1.0F', description: 'float one uppercase F' },
-    ])('Then should NOT generate left mutation for $description * b (equivalent)', ({
-      left,
-    }) => {
-      // Arrange
-      const typeRegistry = createTypeRegistry()
-      const sut = new ArithmeticOperatorDeletionMutator(typeRegistry)
-      const ctx = createArithmeticCtxInMethod(left, '*', 'b', 'testMethod')
+    ])(
+      'Then should NOT generate left mutation for $description * b (equivalent)',
+      ({ left }) => {
+        // Arrange
+        const typeRegistry = createTypeRegistry()
+        const sut = new ArithmeticOperatorDeletionMutator(typeRegistry)
+        const ctx = createArithmeticCtxInMethod(left, '*', 'b', 'testMethod')
 
-      // Act
-      sut.enterArth1Expression(ctx as unknown as Arth1ExpressionContext)
+        // Act
+        sut.enterArth1Expression(ctx as unknown as Arth1ExpressionContext)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(1)
-      expect(sut._mutations[0].replacement).toBe(left)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe(left)
+      }
+    )
 
     it('Then should generate mutations for a - 0L (0 right not identity for -)', () => {
       // Arrange

--- a/test/unit/mutator/emptyReturnMutator.test.ts
+++ b/test/unit/mutator/emptyReturnMutator.test.ts
@@ -103,32 +103,35 @@ describe('EmptyReturnMutator', () => {
       },
     ]
 
-    it.each(
-      testTypes
-    )('Given $returnType return type, When entering return statement, Then creates empty mutation with $expected', testCase => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: testCase.returnType,
-        startLine: 1,
-        endLine: 5,
-        type: testCase.type,
-        ...(testCase.elementType ? { elementType: testCase.elementType } : {}),
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new EmptyReturnMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod(
-        testCase.expression,
-        'testMethod'
-      )
+    it.each(testTypes)(
+      'Given $returnType return type, When entering return statement, Then creates empty mutation with $expected',
+      testCase => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: testCase.returnType,
+          startLine: 1,
+          endLine: 5,
+          type: testCase.type,
+          ...(testCase.elementType
+            ? { elementType: testCase.elementType }
+            : {}),
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new EmptyReturnMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod(
+          testCase.expression,
+          'testMethod'
+        )
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(1)
-      expect(sut._mutations[0].replacement).toBe(testCase.expected)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe(testCase.expected)
+      }
+    )
 
     const excludedTypes = [
       { type: APEX_TYPE.VOID, name: 'void' },
@@ -141,27 +144,28 @@ describe('EmptyReturnMutator', () => {
       { type: APEX_TYPE.TIME, name: 'Time' },
     ]
 
-    it.each(
-      excludedTypes
-    )('Given $name return type, When entering return statement, Then no mutation created', excluded => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: excluded.name,
-        startLine: 1,
-        endLine: 5,
-        type: excluded.type,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new EmptyReturnMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod('something', 'testMethod')
+    it.each(excludedTypes)(
+      'Given $name return type, When entering return statement, Then no mutation created',
+      excluded => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: excluded.name,
+          startLine: 1,
+          endLine: 5,
+          type: excluded.type,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new EmptyReturnMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod('something', 'testMethod')
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(0)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      }
+    )
   })
 
   describe('empty value detection', () => {
@@ -196,18 +200,19 @@ describe('EmptyReturnMutator', () => {
       },
     ]
 
-    it.each(
-      emptyValueCases
-    )('Given $type type with value $value, When checking isEmpty, Then returns $expected', testCase => {
-      // Arrange
-      const sut = new EmptyReturnMutator()
+    it.each(emptyValueCases)(
+      'Given $type type with value $value, When checking isEmpty, Then returns $expected',
+      testCase => {
+        // Arrange
+        const sut = new EmptyReturnMutator()
 
-      // Act
-      const result = sut.isEmptyValue(testCase.type, testCase.value)
+        // Act
+        const result = sut.isEmptyValue(testCase.type, testCase.value)
 
-      // Assert
-      expect(result).toBe(testCase.expected)
-    })
+        // Assert
+        expect(result).toBe(testCase.expected)
+      }
+    )
 
     describe('Double and Decimal zero value edge cases', () => {
       it.each([
@@ -219,16 +224,19 @@ describe('EmptyReturnMutator', () => {
         { type: 'Decimal', value: '0.000', expected: true },
         { type: 'Double', value: '1.0', expected: false },
         { type: 'Decimal', value: '1.0', expected: false },
-      ])('Given $type type with value $value, When checking isEmpty, Then returns $expected', testCase => {
-        // Arrange
-        const sut = new EmptyReturnMutator()
+      ])(
+        'Given $type type with value $value, When checking isEmpty, Then returns $expected',
+        testCase => {
+          // Arrange
+          const sut = new EmptyReturnMutator()
 
-        // Act
-        const result = sut.isEmptyValue(testCase.type, testCase.value)
+          // Act
+          const result = sut.isEmptyValue(testCase.type, testCase.value)
 
-        // Assert
-        expect(result).toBe(testCase.expected)
-      })
+          // Assert
+          expect(result).toBe(testCase.expected)
+        }
+      )
 
       it('Given Double type with 00.0 (not anchored at start), When checking isEmpty, Then returns false', () => {
         // Arrange

--- a/test/unit/mutator/falseReturnMutator.test.ts
+++ b/test/unit/mutator/falseReturnMutator.test.ts
@@ -44,31 +44,32 @@ describe('FalseReturnMutator', () => {
       },
     ]
 
-    it.each(
-      testCases
-    )('Given $name return value, When entering return statement, Then creates false mutation', testCase => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: 'Boolean',
-        startLine: 1,
-        endLine: 5,
-        type: APEX_TYPE.BOOLEAN,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new FalseReturnMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod(
-        testCase.expression,
-        'testMethod'
-      )
+    it.each(testCases)(
+      'Given $name return value, When entering return statement, Then creates false mutation',
+      testCase => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Boolean',
+          startLine: 1,
+          endLine: 5,
+          type: APEX_TYPE.BOOLEAN,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new FalseReturnMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod(
+          testCase.expression,
+          'testMethod'
+        )
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(1)
-      expect(sut._mutations[0].replacement).toBe(testCase.expected)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe(testCase.expected)
+      }
+    )
   })
 
   describe('already false values', () => {
@@ -117,30 +118,31 @@ describe('FalseReturnMutator', () => {
       },
     ]
 
-    it.each(
-      testCases
-    )('Given $typeName return type, When entering return statement, Then no mutation created', testCase => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: testCase.typeName,
-        startLine: 1,
-        endLine: 5,
-        type: testCase.type,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new FalseReturnMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod(
-        testCase.expression,
-        'testMethod'
-      )
+    it.each(testCases)(
+      'Given $typeName return type, When entering return statement, Then no mutation created',
+      testCase => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: testCase.typeName,
+          startLine: 1,
+          endLine: 5,
+          type: testCase.type,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new FalseReturnMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod(
+          testCase.expression,
+          'testMethod'
+        )
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(0)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      }
+    )
   })
 
   describe('validation and edge cases', () => {

--- a/test/unit/mutator/incrementMutator.test.ts
+++ b/test/unit/mutator/incrementMutator.test.ts
@@ -36,29 +36,28 @@ describe('IncrementMutator', () => {
     },
   ]
 
-  describe.each(testCases)('$method', ({
-    method,
-    operator,
-    expectedReplacement,
-  }) => {
-    it(`should add mutation when encountering ${operator} operator`, () => {
-      // Arrange
-      const mockCtx = {
-        childCount: 2,
-        getChild: vi.fn(index => {
-          const terminalNode = new TerminalNode({ text: operator } as Token)
-          return index === 1 ? terminalNode : {}
-        }),
-      } as unknown as ParserRuleContext
+  describe.each(testCases)(
+    '$method',
+    ({ method, operator, expectedReplacement }) => {
+      it(`should add mutation when encountering ${operator} operator`, () => {
+        // Arrange
+        const mockCtx = {
+          childCount: 2,
+          getChild: vi.fn(index => {
+            const terminalNode = new TerminalNode({ text: operator } as Token)
+            return index === 1 ? terminalNode : {}
+          }),
+        } as unknown as ParserRuleContext
 
-      // Act
-      sut[method](mockCtx)
+        // Act
+        sut[method](mockCtx)
 
-      // Assert
-      expect(sut['_mutations']).toHaveLength(1)
-      expect(sut['_mutations'][0].replacement).toBe(expectedReplacement)
-    })
-  })
+        // Assert
+        expect(sut['_mutations']).toHaveLength(1)
+        expect(sut['_mutations'][0].replacement).toBe(expectedReplacement)
+      })
+    }
+  )
 
   const invalidTestCases = [
     {

--- a/test/unit/mutator/negationMutator.test.ts
+++ b/test/unit/mutator/negationMutator.test.ts
@@ -89,31 +89,29 @@ describe('NegationMutator', () => {
       { type: APEX_TYPE.DECIMAL, typeName: 'Decimal' },
     ]
 
-    it.each(
-      numericTypes
-    )('Given $typeName return type, When entering return statement, Then creates negation mutation', ({
-      type,
-      typeName,
-    }) => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: typeName,
-        startLine: 1,
-        endLine: 5,
-        type,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new NegationMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod('value', 'testMethod')
+    it.each(numericTypes)(
+      'Given $typeName return type, When entering return statement, Then creates negation mutation',
+      ({ type, typeName }) => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: typeName,
+          startLine: 1,
+          endLine: 5,
+          type,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new NegationMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod('value', 'testMethod')
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(1)
-      expect(sut._mutations[0].replacement).toBe('-value')
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe('-value')
+      }
+    )
   })
 
   describe('non-numeric type mutations', () => {
@@ -130,30 +128,28 @@ describe('NegationMutator', () => {
       { type: APEX_TYPE.VOID, typeName: 'void' },
     ]
 
-    it.each(
-      nonNumericTypes
-    )('Given $typeName return type, When entering return statement, Then no mutation created', ({
-      type,
-      typeName,
-    }) => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: typeName,
-        startLine: 1,
-        endLine: 5,
-        type,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new NegationMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod('value', 'testMethod')
+    it.each(nonNumericTypes)(
+      'Given $typeName return type, When entering return statement, Then no mutation created',
+      ({ type, typeName }) => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: typeName,
+          startLine: 1,
+          endLine: 5,
+          type,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new NegationMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod('value', 'testMethod')
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(0)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      }
+    )
   })
 
   describe('simple value negation', () => {
@@ -340,27 +336,28 @@ describe('NegationMutator', () => {
       { value: '0.0', description: 'float zero' },
       { value: '0.00', description: 'multi-decimal zero' },
       { value: '0.0d', description: 'float zero with double suffix' },
-    ])('Given Integer method returning $description ($value), When entering return statement, Then no mutation created', ({
-      value,
-    }) => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: 'Integer',
-        startLine: 1,
-        endLine: 5,
-        type: APEX_TYPE.INTEGER,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new NegationMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod(value, 'testMethod')
+    ])(
+      'Given Integer method returning $description ($value), When entering return statement, Then no mutation created',
+      ({ value }) => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Integer',
+          startLine: 1,
+          endLine: 5,
+          type: APEX_TYPE.INTEGER,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new NegationMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod(value, 'testMethod')
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(0)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      }
+    )
 
     it.each([
       { value: '1', description: 'integer one' },
@@ -371,27 +368,28 @@ describe('NegationMutator', () => {
         value: '0.0f',
         description: 'float zero with f suffix (not in regex charset)',
       },
-    ])('Given Integer method returning non-zero $description ($value), When entering return statement, Then mutation is created', ({
-      value,
-    }) => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: 'Integer',
-        startLine: 1,
-        endLine: 5,
-        type: APEX_TYPE.INTEGER,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new NegationMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod(value, 'testMethod')
+    ])(
+      'Given Integer method returning non-zero $description ($value), When entering return statement, Then mutation is created',
+      ({ value }) => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Integer',
+          startLine: 1,
+          endLine: 5,
+          type: APEX_TYPE.INTEGER,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new NegationMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod(value, 'testMethod')
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(1)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+      }
+    )
   })
 
   describe('zero literal prevention', () => {

--- a/test/unit/mutator/nonVoidMethodCallMutator.test.ts
+++ b/test/unit/mutator/nonVoidMethodCallMutator.test.ts
@@ -171,36 +171,34 @@ describe('NonVoidMethodCallMutator', () => {
           { typeName: 'CustomClass', expected: 'null' },
         ]
 
-        it.each(
-          testCases
-        )('Given $typeName variable declaration with method call, When entering statement, Then should replace with $expected', ({
-          typeName,
-          expected,
-        }) => {
-          // Arrange
-          const typeRegistry = createTypeRegistryWithVars(
-            'testMethod',
-            new Map()
-          )
-          const sut = new NonVoidMethodCallMutator(typeRegistry)
-          sut._mutations = []
-          const methodCall = createMethodCallExpression('getValue()')
-          const ctx = createVariableDeclarationStatement(
-            typeName,
-            'x',
-            methodCall
-          )
+        it.each(testCases)(
+          'Given $typeName variable declaration with method call, When entering statement, Then should replace with $expected',
+          ({ typeName, expected }) => {
+            // Arrange
+            const typeRegistry = createTypeRegistryWithVars(
+              'testMethod',
+              new Map()
+            )
+            const sut = new NonVoidMethodCallMutator(typeRegistry)
+            sut._mutations = []
+            const methodCall = createMethodCallExpression('getValue()')
+            const ctx = createVariableDeclarationStatement(
+              typeName,
+              'x',
+              methodCall
+            )
 
-          // Act
-          sut.enterLocalVariableDeclarationStatement(ctx)
+            // Act
+            sut.enterLocalVariableDeclarationStatement(ctx)
 
-          // Assert
-          expect(sut._mutations).toHaveLength(1)
-          expect(sut._mutations[0].replacement).toBe(expected)
-          expect(sut._mutations[0].mutationName).toBe(
-            'NonVoidMethodCallMutator'
-          )
-        })
+            // Assert
+            expect(sut._mutations).toHaveLength(1)
+            expect(sut._mutations[0].replacement).toBe(expected)
+            expect(sut._mutations[0].mutationName).toBe(
+              'NonVoidMethodCallMutator'
+            )
+          }
+        )
       })
 
       it('Given dot expression method call, When entering statement, Then should mutate', () => {
@@ -613,43 +611,40 @@ describe('NonVoidMethodCallMutator', () => {
           { apexType: APEX_TYPE.DATE, fieldName: 'created', expected: 'null' },
         ]
 
-        it.each(
-          apexTypeTestCases
-        )('Given SObject field of ApexType $apexType, When assigning method call, Then should return $expected', ({
-          apexType,
-          fieldName,
-          expected,
-        }) => {
-          // Arrange
-          const fieldMap = new Map([
-            ['account', new Map([[fieldName.toLowerCase(), apexType]])],
-          ])
-          const matcher = createSObjectFieldMatcher(
-            new Set(['account']),
-            fieldMap
-          )
-          const typeRegistry = createTypeRegistryWithVars(
-            'testMethod',
-            new Map([['acc', 'account']]),
-            new Map(),
-            [matcher]
-          )
-          const sut = new NonVoidMethodCallMutator(typeRegistry)
-          sut._mutations = []
-          const methodCall = createMethodCallExpression('getValue()')
-          const assignCtx = createAssignExpression(
-            `acc.${fieldName}`,
-            methodCall
-          )
-          setEnclosingMethod(assignCtx, 'testMethod')
+        it.each(apexTypeTestCases)(
+          'Given SObject field of ApexType $apexType, When assigning method call, Then should return $expected',
+          ({ apexType, fieldName, expected }) => {
+            // Arrange
+            const fieldMap = new Map([
+              ['account', new Map([[fieldName.toLowerCase(), apexType]])],
+            ])
+            const matcher = createSObjectFieldMatcher(
+              new Set(['account']),
+              fieldMap
+            )
+            const typeRegistry = createTypeRegistryWithVars(
+              'testMethod',
+              new Map([['acc', 'account']]),
+              new Map(),
+              [matcher]
+            )
+            const sut = new NonVoidMethodCallMutator(typeRegistry)
+            sut._mutations = []
+            const methodCall = createMethodCallExpression('getValue()')
+            const assignCtx = createAssignExpression(
+              `acc.${fieldName}`,
+              methodCall
+            )
+            setEnclosingMethod(assignCtx, 'testMethod')
 
-          // Act
-          sut.enterAssignExpression(assignCtx)
+            // Act
+            sut.enterAssignExpression(assignCtx)
 
-          // Assert
-          expect(sut._mutations).toHaveLength(1)
-          expect(sut._mutations[0].replacement).toBe(expected)
-        })
+            // Assert
+            expect(sut._mutations).toHaveLength(1)
+            expect(sut._mutations[0].replacement).toBe(expected)
+          }
+        )
       })
     })
 

--- a/test/unit/mutator/nullReturnMutator.test.ts
+++ b/test/unit/mutator/nullReturnMutator.test.ts
@@ -60,31 +60,32 @@ describe('NullReturnMutator', () => {
       },
     ]
 
-    it.each(
-      testCases
-    )('Given $name return type, When entering return statement, Then creates null mutation', testCase => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: testCase.name,
-        startLine: 1,
-        endLine: 5,
-        type: testCase.type,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new NullReturnMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod(
-        testCase.expression,
-        'testMethod'
-      )
+    it.each(testCases)(
+      'Given $name return type, When entering return statement, Then creates null mutation',
+      testCase => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: testCase.name,
+          startLine: 1,
+          endLine: 5,
+          type: testCase.type,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new NullReturnMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod(
+          testCase.expression,
+          'testMethod'
+        )
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(1)
-      expect(sut._mutations[0].replacement).toBe(testCase.expected)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe(testCase.expected)
+      }
+    )
   })
 
   describe('primitive and non-primitive return types', () => {
@@ -119,35 +120,36 @@ describe('NullReturnMutator', () => {
       },
     ]
 
-    it.each(
-      testCases
-    )('Given $typeName return type, When entering return statement, Then shouldMutate=$shouldMutate', testCase => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: testCase.typeName,
-        startLine: 1,
-        endLine: 5,
-        type: testCase.type,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new NullReturnMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod(
-        testCase.expression,
-        'testMethod'
-      )
+    it.each(testCases)(
+      'Given $typeName return type, When entering return statement, Then shouldMutate=$shouldMutate',
+      testCase => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: testCase.typeName,
+          startLine: 1,
+          endLine: 5,
+          type: testCase.type,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new NullReturnMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod(
+          testCase.expression,
+          'testMethod'
+        )
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      if (testCase.shouldMutate) {
-        expect(sut._mutations).toHaveLength(1)
-        expect(sut._mutations[0].replacement).toBe(testCase.expected)
-      } else {
-        expect(sut._mutations).toHaveLength(0)
+        // Assert
+        if (testCase.shouldMutate) {
+          expect(sut._mutations).toHaveLength(1)
+          expect(sut._mutations[0].replacement).toBe(testCase.expected)
+        } else {
+          expect(sut._mutations).toHaveLength(0)
+        }
       }
-    })
+    )
   })
 
   describe('already null values', () => {

--- a/test/unit/mutator/trueReturnMutator.test.ts
+++ b/test/unit/mutator/trueReturnMutator.test.ts
@@ -44,31 +44,32 @@ describe('TrueReturnMutator', () => {
       },
     ]
 
-    it.each(
-      testCases
-    )('Given $name return value, When entering return statement, Then creates true mutation', testCase => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: 'Boolean',
-        startLine: 1,
-        endLine: 5,
-        type: APEX_TYPE.BOOLEAN,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new TrueReturnMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod(
-        testCase.expression,
-        'testMethod'
-      )
+    it.each(testCases)(
+      'Given $name return value, When entering return statement, Then creates true mutation',
+      testCase => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: 'Boolean',
+          startLine: 1,
+          endLine: 5,
+          type: APEX_TYPE.BOOLEAN,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new TrueReturnMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod(
+          testCase.expression,
+          'testMethod'
+        )
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(1)
-      expect(sut._mutations[0].replacement).toBe(testCase.expected)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(1)
+        expect(sut._mutations[0].replacement).toBe(testCase.expected)
+      }
+    )
   })
 
   describe('already true values', () => {
@@ -117,30 +118,31 @@ describe('TrueReturnMutator', () => {
       },
     ]
 
-    it.each(
-      testCases
-    )('Given $typeName return type, When entering return statement, Then no mutation created', testCase => {
-      // Arrange
-      const typeTable = new Map<string, ApexMethod>()
-      typeTable.set('testMethod', {
-        returnType: testCase.typeName,
-        startLine: 1,
-        endLine: 5,
-        type: testCase.type,
-      })
-      const typeRegistry = createTypeRegistry(typeTable)
-      const sut = new TrueReturnMutator(typeRegistry)
-      const returnCtx = createReturnCtxInMethod(
-        testCase.expression,
-        'testMethod'
-      )
+    it.each(testCases)(
+      'Given $typeName return type, When entering return statement, Then no mutation created',
+      testCase => {
+        // Arrange
+        const typeTable = new Map<string, ApexMethod>()
+        typeTable.set('testMethod', {
+          returnType: testCase.typeName,
+          startLine: 1,
+          endLine: 5,
+          type: testCase.type,
+        })
+        const typeRegistry = createTypeRegistry(typeTable)
+        const sut = new TrueReturnMutator(typeRegistry)
+        const returnCtx = createReturnCtxInMethod(
+          testCase.expression,
+          'testMethod'
+        )
 
-      // Act
-      sut.enterReturnStatement(returnCtx)
+        // Act
+        sut.enterReturnStatement(returnCtx)
 
-      // Assert
-      expect(sut._mutations).toHaveLength(0)
-    })
+        // Assert
+        expect(sut._mutations).toHaveLength(0)
+      }
+    )
   })
 
   describe('validation and edge cases', () => {

--- a/test/unit/mutator/unaryOperatorInsertionMutator.test.ts
+++ b/test/unit/mutator/unaryOperatorInsertionMutator.test.ts
@@ -251,28 +251,26 @@ describe('UnaryOperatorInsertionMutator', () => {
 
   describe('Given a primary expression with a numeric type and TypeRegistry', () => {
     describe('When entering the expression', () => {
-      it.each([
-        'integer',
-        'long',
-        'double',
-        'decimal',
-      ])('Then should create 4 mutations for %s variable', typeName => {
-        // Arrange
-        const typeRegistry = TestUtil.createTypeRegistry(
-          new Map(),
-          new Map([['testMethod', new Map([['x', typeName]])]])
-        )
-        const sut = new UnaryOperatorInsertionMutator(typeRegistry)
-        const ctx = createPrimaryExpression('x')
-        const methodCtx = createMethodParent('testMethod')
-        TestUtil.setParent(ctx, methodCtx)
+      it.each(['integer', 'long', 'double', 'decimal'])(
+        'Then should create 4 mutations for %s variable',
+        typeName => {
+          // Arrange
+          const typeRegistry = TestUtil.createTypeRegistry(
+            new Map(),
+            new Map([['testMethod', new Map([['x', typeName]])]])
+          )
+          const sut = new UnaryOperatorInsertionMutator(typeRegistry)
+          const ctx = createPrimaryExpression('x')
+          const methodCtx = createMethodParent('testMethod')
+          TestUtil.setParent(ctx, methodCtx)
 
-        // Act
-        sut.enterPrimaryExpression(ctx)
+          // Act
+          sut.enterPrimaryExpression(ctx)
 
-        // Assert
-        expect(sut._mutations).toHaveLength(4)
-      })
+          // Assert
+          expect(sut._mutations).toHaveLength(4)
+        }
+      )
     })
   })
 

--- a/test/unit/service/mutationTestingService.test.ts
+++ b/test/unit/service/mutationTestingService.test.ts
@@ -366,159 +366,154 @@ describe('MutationTestingService', () => {
         },
       ]
 
-      it.each(testCases)('should handle $description', async ({
-        testResult,
-        expectedMutants,
-        error,
-        updateError,
-      }) => {
-        // Arrange
-        let updateCallCount = 0
-        vi.mocked(ApexClassRepository).mockImplementation(
-          class {
-            read = vi.fn().mockImplementation((name: string) => {
-              if (name === 'TestClass') return Promise.resolve(mockApexClass)
-              return Promise.resolve(mockTestClass)
-            })
-            update = vi.fn().mockImplementation(() => {
-              updateCallCount++
-              // Calls 1-2: verify compile passes; call 3: mutation deploy may
-              // fail (updateError); call 4+ (rollback) must succeed so the
-              // rollback-failure propagation isn't what the test is asserting.
-              if (updateCallCount <= 2) return Promise.resolve({})
-              if (updateCallCount === 3 && updateError)
-                return Promise.reject(updateError)
-              return Promise.resolve({})
-            })
-            getApexClassDependencies = vi.fn().mockResolvedValue([
-              {
-                Id: 'dep1',
-                RefMetadataComponentType: 'ApexClass',
-                RefMetadataComponentName: 'TestDep',
-              },
-              {
-                Id: 'dep2',
-                RefMetadataComponentType: 'StandardEntity',
-                RefMetadataComponentName: 'Account',
-              },
-              {
-                Id: 'dep3',
-                RefMetadataComponentType: 'CustomObject',
-                RefMetadataComponentName: 'Custom__c',
-              },
-            ] as MetadataComponentDependency[])
-          }
-        )
-        vi.mocked(MutantGenerator).mockImplementation(
-          class {
-            compute = vi
-              .fn()
-              .mockReturnValue({ mutations: [mockMutation], tokenStream: {} })
-            mutate = vi.fn().mockReturnValue('mutated code')
-          }
-        )
-        vi.mocked(ApexTestRunner).mockImplementation(
-          class {
-            runTestMethods = vi.fn().mockImplementation(() => {
-              if (error) {
-                return Promise.reject(error)
-              }
-              return Promise.resolve(testResult)
-            })
-            getTestMethodsPerLines = vi.fn().mockResolvedValue({
-              outcome: 'Passed',
-              passing: 1,
-              failing: 0,
-              testsRan: 1,
-              testMethodsPerLine: new Map([[1, new Set(['testMethodA'])]]),
-            })
-          }
-        )
+      it.each(testCases)(
+        'should handle $description',
+        async ({ testResult, expectedMutants, error, updateError }) => {
+          // Arrange
+          let updateCallCount = 0
+          vi.mocked(ApexClassRepository).mockImplementation(
+            class {
+              read = vi.fn().mockImplementation((name: string) => {
+                if (name === 'TestClass') return Promise.resolve(mockApexClass)
+                return Promise.resolve(mockTestClass)
+              })
+              update = vi.fn().mockImplementation(() => {
+                updateCallCount++
+                // Calls 1-2: verify compile passes; call 3: mutation deploy may
+                // fail (updateError); call 4+ (rollback) must succeed so the
+                // rollback-failure propagation isn't what the test is asserting.
+                if (updateCallCount <= 2) return Promise.resolve({})
+                if (updateCallCount === 3 && updateError)
+                  return Promise.reject(updateError)
+                return Promise.resolve({})
+              })
+              getApexClassDependencies = vi.fn().mockResolvedValue([
+                {
+                  Id: 'dep1',
+                  RefMetadataComponentType: 'ApexClass',
+                  RefMetadataComponentName: 'TestDep',
+                },
+                {
+                  Id: 'dep2',
+                  RefMetadataComponentType: 'StandardEntity',
+                  RefMetadataComponentName: 'Account',
+                },
+                {
+                  Id: 'dep3',
+                  RefMetadataComponentType: 'CustomObject',
+                  RefMetadataComponentName: 'Custom__c',
+                },
+              ] as MetadataComponentDependency[])
+            }
+          )
+          vi.mocked(MutantGenerator).mockImplementation(
+            class {
+              compute = vi
+                .fn()
+                .mockReturnValue({ mutations: [mockMutation], tokenStream: {} })
+              mutate = vi.fn().mockReturnValue('mutated code')
+            }
+          )
+          vi.mocked(ApexTestRunner).mockImplementation(
+            class {
+              runTestMethods = vi.fn().mockImplementation(() => {
+                if (error) {
+                  return Promise.reject(error)
+                }
+                return Promise.resolve(testResult)
+              })
+              getTestMethodsPerLines = vi.fn().mockResolvedValue({
+                outcome: 'Passed',
+                passing: 1,
+                failing: 0,
+                testsRan: 1,
+                testMethodsPerLine: new Map([[1, new Set(['testMethodA'])]]),
+              })
+            }
+          )
 
-        // Act
-        const result = await sut.process()
+          // Act
+          const result = await sut.process()
 
-        // Assert
-        expect(result).toEqual({
-          sourceFile: 'TestClass',
-          sourceFileContent: mockApexClass.Body,
-          testFile: 'TestClassTest',
-          mutants: expectedMutants,
-        })
-        expect(progress.start).toHaveBeenCalled()
-        expect(progress.finish).toHaveBeenCalled()
-      })
+          // Assert
+          expect(result).toEqual({
+            sourceFile: 'TestClass',
+            sourceFileContent: mockApexClass.Body,
+            testFile: 'TestClassTest',
+            mutants: expectedMutants,
+          })
+          expect(progress.start).toHaveBeenCalled()
+          expect(progress.finish).toHaveBeenCalled()
+        }
+      )
 
       // Rollback-failure variant: each error classification path is also
       // exercised with a failing rollback so we catch a regression where the
       // service swallows rollback errors or leaks partial results on throw.
       // See Test-I1: the happy-path parametric test above allowed call 4+ to
       // always resolve, which hid this surface.
-      it.each(
-        testCases
-      )('should re-throw rollback failure while still classifying the mutant ($description)', async ({
-        testResult,
-        error,
-        updateError,
-      }) => {
-        // Arrange
-        let updateCallCount = 0
-        vi.mocked(ApexClassRepository).mockImplementation(
-          class {
-            read = vi.fn().mockImplementation((name: string) => {
-              if (name === 'TestClass') return Promise.resolve(mockApexClass)
-              return Promise.resolve(mockTestClass)
-            })
-            update = vi.fn().mockImplementation(() => {
-              updateCallCount++
-              if (updateCallCount <= 2) return Promise.resolve({})
-              if (updateCallCount === 3 && updateError)
-                return Promise.reject(updateError)
-              if (updateCallCount === 3) return Promise.resolve({})
-              // Call 4 = rollback — always fails in this variant.
-              return Promise.reject(new Error('rollback network down'))
-            })
-            getApexClassDependencies = vi
-              .fn()
-              .mockResolvedValue([] as MetadataComponentDependency[])
-          }
-        )
-        vi.mocked(MutantGenerator).mockImplementation(
-          class {
-            compute = vi.fn().mockReturnValue({
-              mutations: [mockMutation],
-              tokenStream: {},
-            })
-            mutate = vi.fn().mockReturnValue('mutated code')
-          }
-        )
-        vi.mocked(ApexTestRunner).mockImplementation(
-          class {
-            runTestMethods = vi.fn().mockImplementation(() => {
-              if (error) return Promise.reject(error)
-              return Promise.resolve(testResult)
-            })
-            getTestMethodsPerLines = vi.fn().mockResolvedValue({
-              outcome: 'Passed',
-              passing: 1,
-              failing: 0,
-              testsRan: 1,
-              testMethodsPerLine: new Map([[1, new Set(['testMethodA'])]]),
-            })
-          }
-        )
+      it.each(testCases)(
+        'should re-throw rollback failure while still classifying the mutant ($description)',
+        async ({ testResult, error, updateError }) => {
+          // Arrange
+          let updateCallCount = 0
+          vi.mocked(ApexClassRepository).mockImplementation(
+            class {
+              read = vi.fn().mockImplementation((name: string) => {
+                if (name === 'TestClass') return Promise.resolve(mockApexClass)
+                return Promise.resolve(mockTestClass)
+              })
+              update = vi.fn().mockImplementation(() => {
+                updateCallCount++
+                if (updateCallCount <= 2) return Promise.resolve({})
+                if (updateCallCount === 3 && updateError)
+                  return Promise.reject(updateError)
+                if (updateCallCount === 3) return Promise.resolve({})
+                // Call 4 = rollback — always fails in this variant.
+                return Promise.reject(new Error('rollback network down'))
+              })
+              getApexClassDependencies = vi
+                .fn()
+                .mockResolvedValue([] as MetadataComponentDependency[])
+            }
+          )
+          vi.mocked(MutantGenerator).mockImplementation(
+            class {
+              compute = vi.fn().mockReturnValue({
+                mutations: [mockMutation],
+                tokenStream: {},
+              })
+              mutate = vi.fn().mockReturnValue('mutated code')
+            }
+          )
+          vi.mocked(ApexTestRunner).mockImplementation(
+            class {
+              runTestMethods = vi.fn().mockImplementation(() => {
+                if (error) return Promise.reject(error)
+                return Promise.resolve(testResult)
+              })
+              getTestMethodsPerLines = vi.fn().mockResolvedValue({
+                outcome: 'Passed',
+                passing: 1,
+                failing: 0,
+                testsRan: 1,
+                testMethodsPerLine: new Map([[1, new Set(['testMethodA'])]]),
+              })
+            }
+          )
 
-        // Act & Assert — rollback failure must propagate, never silently swallow
-        await expect(sut.process()).rejects.toThrow(
-          /Rollback of 'TestClass' failed/
-        )
-        // rollback was in fact attempted (call 4)
-        expect(updateCallCount).toBe(4)
-        // A warning spinner message precedes the throw
-        expect(spinner.stop).toHaveBeenCalledWith(
-          expect.stringContaining('Rollback FAILED')
-        )
-      })
+          // Act & Assert — rollback failure must propagate, never silently swallow
+          await expect(sut.process()).rejects.toThrow(
+            /Rollback of 'TestClass' failed/
+          )
+          // rollback was in fact attempted (call 4)
+          expect(updateCallCount).toBe(4)
+          // A warning spinner message precedes the throw
+          expect(spinner.stop).toHaveBeenCalledWith(
+            expect.stringContaining('Rollback FAILED')
+          )
+        }
+      )
     })
 
     describe('When dry-run is enabled', () => {
@@ -1386,24 +1381,24 @@ describe('MutationTestingService', () => {
         },
       ]
 
-      it.each(scoreTestCases)('should calculate correct score $description', ({
-        mutants,
-        expectedScore,
-      }) => {
-        // Arrange
-        const mockResult = {
-          sourceFile: 'TestClass',
-          sourceFileContent: 'content',
-          testFile: 'TestClassTest',
-          mutants,
-        } as ApexMutationTestResult
+      it.each(scoreTestCases)(
+        'should calculate correct score $description',
+        ({ mutants, expectedScore }) => {
+          // Arrange
+          const mockResult = {
+            sourceFile: 'TestClass',
+            sourceFileContent: 'content',
+            testFile: 'TestClassTest',
+            mutants,
+          } as ApexMutationTestResult
 
-        // Act
-        const score = sut.calculateScore(mockResult)
+          // Act
+          const score = sut.calculateScore(mockResult)
 
-        // Assert
-        expect(score).toBe(expectedScore)
-      })
+          // Assert
+          expect(score).toBe(expectedScore)
+        }
+      )
     })
 
     describe('When discoverTypes is called', () => {

--- a/test/unit/type/ApexMethod.test.ts
+++ b/test/unit/type/ApexMethod.test.ts
@@ -15,16 +15,16 @@ describe('getDefaultValueForApexType', () => {
       { apexType: APEX_TYPE.DECIMAL, expected: '0.0' },
       { apexType: APEX_TYPE.BOOLEAN, expected: 'false' },
       { apexType: APEX_TYPE.BLOB, expected: "Blob.valueOf('')" },
-    ])('Given $apexType type, When getting default value, Then returns $expected', ({
-      apexType,
-      expected,
-    }) => {
-      // Arrange & Act
-      const result = getDefaultValueForApexType(apexType)
+    ])(
+      'Given $apexType type, When getting default value, Then returns $expected',
+      ({ apexType, expected }) => {
+        // Arrange & Act
+        const result = getDefaultValueForApexType(apexType)
 
-      // Assert
-      expect(result).toBe(expected)
-    })
+        // Assert
+        expect(result).toBe(expected)
+      }
+    )
   })
 
   describe('collection types with typeName', () => {
@@ -44,17 +44,16 @@ describe('getDefaultValueForApexType', () => {
         typeName: 'Map<String, Integer>',
         expected: 'new Map<String, Integer>()',
       },
-    ])('Given $apexType type with typeName, When getting default value, Then returns new instance', ({
-      apexType,
-      typeName,
-      expected,
-    }) => {
-      // Arrange & Act
-      const result = getDefaultValueForApexType(apexType, typeName)
+    ])(
+      'Given $apexType type with typeName, When getting default value, Then returns new instance',
+      ({ apexType, typeName, expected }) => {
+        // Arrange & Act
+        const result = getDefaultValueForApexType(apexType, typeName)
 
-      // Assert
-      expect(result).toBe(expected)
-    })
+        // Assert
+        expect(result).toBe(expected)
+      }
+    )
   })
 
   it('Given SOBJECT type with typeName, When getting default value, Then returns new instance', () => {
@@ -113,14 +112,15 @@ describe('getDefaultValueForApexType', () => {
       { apexType: APEX_TYPE.TIME, label: 'TIME' },
       { apexType: APEX_TYPE.OBJECT, label: 'OBJECT' },
       { apexType: APEX_TYPE.APEX_CLASS, label: 'APEX_CLASS' },
-    ])('Given $label type, When getting default value, Then returns null', ({
-      apexType,
-    }) => {
-      // Arrange & Act
-      const result = getDefaultValueForApexType(apexType)
+    ])(
+      'Given $label type, When getting default value, Then returns null',
+      ({ apexType }) => {
+        // Arrange & Act
+        const result = getDefaultValueForApexType(apexType)
 
-      // Assert — these types have no default literal value and fall through to return null
-      expect(result).toBeNull()
-    })
+        // Assert — these types have no default literal value and fall through to return null
+        expect(result).toBeNull()
+      }
+    )
   })
 })

--- a/test/unit/type/TypeRegistry.test.ts
+++ b/test/unit/type/TypeRegistry.test.ts
@@ -478,43 +478,37 @@ describe('TypeRegistry', () => {
   })
 
   describe('isNumericOperand', () => {
-    it.each([
-      'Integer',
-      'Long',
-      'Double',
-      'Decimal',
-    ])('Given variable of numeric type %s, When isNumericOperand, Then returns true', (typeName: string) => {
-      // Arrange
-      const registry = new TypeRegistry(
-        new Map(),
-        new Map([['myMethod', new Map([['n', typeName]])]]),
-        new Map(),
-        []
-      )
+    it.each(['Integer', 'Long', 'Double', 'Decimal'])(
+      'Given variable of numeric type %s, When isNumericOperand, Then returns true',
+      (typeName: string) => {
+        // Arrange
+        const registry = new TypeRegistry(
+          new Map(),
+          new Map([['myMethod', new Map([['n', typeName]])]]),
+          new Map(),
+          []
+        )
 
-      // Act & Assert
-      expect(registry.isNumericOperand('myMethod', 'n')).toBe(true)
-    })
+        // Act & Assert
+        expect(registry.isNumericOperand('myMethod', 'n')).toBe(true)
+      }
+    )
 
-    it.each([
-      'String',
-      'Boolean',
-      'Date',
-      'DateTime',
-      'Blob',
-      'Id',
-    ])('Given variable of non-numeric type %s, When isNumericOperand, Then returns false', (typeName: string) => {
-      // Arrange
-      const registry = new TypeRegistry(
-        new Map(),
-        new Map([['myMethod', new Map([['x', typeName]])]]),
-        new Map(),
-        []
-      )
+    it.each(['String', 'Boolean', 'Date', 'DateTime', 'Blob', 'Id'])(
+      'Given variable of non-numeric type %s, When isNumericOperand, Then returns false',
+      (typeName: string) => {
+        // Arrange
+        const registry = new TypeRegistry(
+          new Map(),
+          new Map([['myMethod', new Map([['x', typeName]])]]),
+          new Map(),
+          []
+        )
 
-      // Act & Assert
-      expect(registry.isNumericOperand('myMethod', 'x')).toBe(false)
-    })
+        // Act & Assert
+        expect(registry.isNumericOperand('myMethod', 'x')).toBe(false)
+      }
+    )
 
     it('Given string literal expression, When isNumericOperand, Then returns false', () => {
       // Arrange
@@ -544,45 +538,51 @@ describe('TypeRegistry', () => {
       ['Long', APEX_TYPE.LONG],
       ['Double', APEX_TYPE.DOUBLE],
       ['Decimal', APEX_TYPE.DECIMAL],
-    ])('Given method returning %s, When isNumericReturn, Then returns true', (returnType: string, apexType: ApexType) => {
-      // Arrange
-      const registry = new TypeRegistry(
-        new Map([
-          [
-            'myMethod',
-            { returnType, startLine: 1, endLine: 5, type: apexType },
-          ],
-        ]),
-        new Map(),
-        new Map(),
-        []
-      )
+    ])(
+      'Given method returning %s, When isNumericReturn, Then returns true',
+      (returnType: string, apexType: ApexType) => {
+        // Arrange
+        const registry = new TypeRegistry(
+          new Map([
+            [
+              'myMethod',
+              { returnType, startLine: 1, endLine: 5, type: apexType },
+            ],
+          ]),
+          new Map(),
+          new Map(),
+          []
+        )
 
-      // Act & Assert
-      expect(registry.isNumericReturn('myMethod')).toBe(true)
-    })
+        // Act & Assert
+        expect(registry.isNumericReturn('myMethod')).toBe(true)
+      }
+    )
 
     it.each([
       ['String', APEX_TYPE.STRING],
       ['Boolean', APEX_TYPE.BOOLEAN],
       ['void', APEX_TYPE.VOID],
-    ])('Given method returning non-numeric type %s, When isNumericReturn, Then returns false', (returnType: string, apexType: ApexType) => {
-      // Arrange
-      const registry = new TypeRegistry(
-        new Map([
-          [
-            'myMethod',
-            { returnType, startLine: 1, endLine: 5, type: apexType },
-          ],
-        ]),
-        new Map(),
-        new Map(),
-        []
-      )
+    ])(
+      'Given method returning non-numeric type %s, When isNumericReturn, Then returns false',
+      (returnType: string, apexType: ApexType) => {
+        // Arrange
+        const registry = new TypeRegistry(
+          new Map([
+            [
+              'myMethod',
+              { returnType, startLine: 1, endLine: 5, type: apexType },
+            ],
+          ]),
+          new Map(),
+          new Map(),
+          []
+        )
 
-      // Act & Assert
-      expect(registry.isNumericReturn('myMethod')).toBe(false)
-    })
+        // Act & Assert
+        expect(registry.isNumericReturn('myMethod')).toBe(false)
+      }
+    )
 
     it('Given unknown method, When isNumericReturn, Then returns false', () => {
       // Arrange
@@ -609,19 +609,22 @@ describe('TypeRegistry', () => {
       ['time', APEX_TYPE.TIME],
       ['sobject', APEX_TYPE.SOBJECT],
       ['object', APEX_TYPE.OBJECT],
-    ])('Given %s primitive type name, When classifyApexType, Then returns %s (not the VOID fallback)', (typeName: string, expectedType: ApexType) => {
-      // Arrange — use isNumericOperand: when type resolves to a known non-STRING type it returns a specific value.
-      // We drive via resolveType with a variable whose type is the primitive name.
-      const variableScopes = new Map([['m', new Map([['x', typeName]])]])
-      const sut = new TypeRegistry(new Map(), variableScopes, new Map(), [])
+    ])(
+      'Given %s primitive type name, When classifyApexType, Then returns %s (not the VOID fallback)',
+      (typeName: string, expectedType: ApexType) => {
+        // Arrange — use isNumericOperand: when type resolves to a known non-STRING type it returns a specific value.
+        // We drive via resolveType with a variable whose type is the primitive name.
+        const variableScopes = new Map([['m', new Map([['x', typeName]])]])
+        const sut = new TypeRegistry(new Map(), variableScopes, new Map(), [])
 
-      // Act
-      const result = sut.resolveType('m', 'x')
+        // Act
+        const result = sut.resolveType('m', 'x')
 
-      // Assert — result must not be null and the apexType must come from the map, not the VOID fallback
-      expect(result).not.toBeNull()
-      expect(result!.apexType).toBe(expectedType)
-    })
+        // Assert — result must not be null and the apexType must come from the map, not the VOID fallback
+        expect(result).not.toBeNull()
+        expect(result!.apexType).toBe(expectedType)
+      }
+    )
 
     it('Given void type name with a matcher that would match anything, When classifyApexType, Then primitive map takes precedence and returns VOID not OBJECT', () => {
       // Arrange — a matcher that matches 'void' would return OBJECT if the primitive map entry is missing.
@@ -665,27 +668,30 @@ describe('TypeRegistry', () => {
       [APEX_TYPE.SET, 'Set'],
       [APEX_TYPE.MAP, 'Map'],
       [APEX_TYPE.APEX_CLASS, 'Object'],
-    ])('Given field of ApexType %s, When resolveDottedExpression returns that type, Then typeName is %s', (fieldApexType: ApexType, expectedTypeName: string) => {
-      // Arrange
-      const matcher: TypeMatcher = {
-        matches: vi.fn().mockReturnValue(true),
-        collect: vi.fn(),
-        collectedTypes: new Set(),
-        getFieldType: vi.fn().mockReturnValue(fieldApexType),
+    ])(
+      'Given field of ApexType %s, When resolveDottedExpression returns that type, Then typeName is %s',
+      (fieldApexType: ApexType, expectedTypeName: string) => {
+        // Arrange
+        const matcher: TypeMatcher = {
+          matches: vi.fn().mockReturnValue(true),
+          collect: vi.fn(),
+          collectedTypes: new Set(),
+          getFieldType: vi.fn().mockReturnValue(fieldApexType),
+        }
+        const variableScopes = new Map([['m', new Map([['obj', 'SomeType']])]])
+        const sut = new TypeRegistry(new Map(), variableScopes, new Map(), [
+          matcher,
+        ])
+
+        // Act
+        const result = sut.resolveType('m', 'obj.someField')
+
+        // Assert
+        expect(result).not.toBeNull()
+        expect(result!.apexType).toBe(fieldApexType)
+        expect(result!.typeName).toBe(expectedTypeName)
       }
-      const variableScopes = new Map([['m', new Map([['obj', 'SomeType']])]])
-      const sut = new TypeRegistry(new Map(), variableScopes, new Map(), [
-        matcher,
-      ])
-
-      // Act
-      const result = sut.resolveType('m', 'obj.someField')
-
-      // Assert
-      expect(result).not.toBeNull()
-      expect(result!.apexType).toBe(fieldApexType)
-      expect(result!.typeName).toBe(expectedTypeName)
-    })
+    )
   })
 
   describe('resolveDottedExpression — rootType guard', () => {
@@ -733,34 +739,39 @@ describe('TypeRegistry', () => {
       ['String[]', APEX_TYPE.LIST],
       ['Set<Integer>', APEX_TYPE.SET],
       ['Map<String,Integer>', APEX_TYPE.MAP],
-    ])('Given variable of type %s, When resolveType, Then classifies as %s', (typeName: string, expectedType: ApexType) => {
-      // Arrange
-      const variableScopes = new Map([['myMethod', new Map([['x', typeName]])]])
-      const registry = new TypeRegistry(
-        new Map([
-          [
-            'myMethod',
-            {
-              returnType: 'void',
-              startLine: 1,
-              endLine: 5,
-              type: APEX_TYPE.VOID,
-            },
-          ],
-        ]),
-        variableScopes,
-        new Map(),
-        []
-      )
+    ])(
+      'Given variable of type %s, When resolveType, Then classifies as %s',
+      (typeName: string, expectedType: ApexType) => {
+        // Arrange
+        const variableScopes = new Map([
+          ['myMethod', new Map([['x', typeName]])],
+        ])
+        const registry = new TypeRegistry(
+          new Map([
+            [
+              'myMethod',
+              {
+                returnType: 'void',
+                startLine: 1,
+                endLine: 5,
+                type: APEX_TYPE.VOID,
+              },
+            ],
+          ]),
+          variableScopes,
+          new Map(),
+          []
+        )
 
-      // Act
-      const result = registry.resolveType('myMethod', 'x')
+        // Act
+        const result = registry.resolveType('myMethod', 'x')
 
-      // Assert
-      expect(result).not.toBeNull()
-      expect(result!.apexType).toBe(expectedType)
-      expect(result!.typeName).toBe(typeName)
-    })
+        // Assert
+        expect(result).not.toBeNull()
+        expect(result!.apexType).toBe(expectedType)
+        expect(result!.typeName).toBe(typeName)
+      }
+    )
 
     it('Given variable type matching a matcher, When resolveType, Then classifies as OBJECT', () => {
       // Arrange


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->

# Explain your changes

---

## Background

The plugin declared `engines.node: ">=20"`, but the dependency graph stopped supporting Node 20 some time ago — `re2` (a native prod dependency) requires `^22.22.2 || ^24.15.0 || >=26.0.0` and `@commitlint/config-conventional` requires `>=22.12.0`. Nothing enforced consistency between the declared range and the graph, all seven CI jobs pinned `node-version: 24`, and the publish flow relied on `npm shrinkwrap`, a command npm 12 removed outright.

## Intuition

Three moves, one PR:

1. **Declare what is actually supported, and gate it.** `engines.node` becomes the disjoint range `^22.22 || ^24.15 || >=26` — exactly the tested 22/24/26 lines, rejecting untested odd lines (23/25) at install time. A new `lint:engine` script (`ls-engines`) fails whenever the declared range over-claims the dependency graph or the running node falls outside it (empirically: the old `>=20` field makes it exit 2). It runs blocking in the pre-push hook and as a PR check.
2. **Prove every supported line in CI.** `reusable-build.yml` runs a `[22, 24, 26]` matrix (`fail-fast: false`), inherited by both the PR and main-push workflows. Two silent-void traps are handled: the wireit GitHub-Actions cache step is removed on matrix legs (wireit fingerprints by file inputs, not node version — the first green leg would let the other two skip execution), and the coverage artifact name is suffixed per leg (upload-artifact v4+ rejects duplicates). All non-matrix jobs move from `24` to `latest`.
3. **Unbreak publish on npm 12.** `npm shrinkwrap` no longer exists (exit 1 aborts `prepublishOnly`), and npm 12 strips `npm-shrinkwrap.json` from published tarballs even when listed in `files[]` (probed empirically both ways). `prepublishOnly` becomes `shx cp package-lock.json npm-shrinkwrap.json`: publish is unblocked, and the `files[]` entry is kept so the locked tree ships again automatically if npm ever re-honours it.

## Code

- `package.json` — engines range; `lint:engine` script (plain, not wireit-wrapped: wireit cannot fingerprint the ambient node version); `ls-engines@^0.10.1` devDependency; `prepublishOnly` copy; patch bumps (`@biomejs/biome ^2.5.4`, `@salesforce/core ^8.32.3` — no majors existed to take).
- `.husky/pre-push` — `npm run lint:engine` appended, blocking (the existing outdated/audit/deps trio stays advisory).
- `.github/workflows/` — matrix + cache removal + artifact suffix in `reusable-build.yml`; `node-version: latest` in `npm-service.yml` (×2), `reusable-perf.yml` (wireit cache kept — non-matrix), `on-pull-request.yml` (×2, plus a `Check engines` step in the npm-lint job), `run-e2e-tests.yml`.
- `test/unit/**` (13 files) — mechanical biome 2.5.4 reformat riding with the formatter bump; verified token-identical to main (no test dropped, no assertion changed).
- `CONTRIBUTING.md` / `DESIGN.md` — Node 22.22 floor stated; new "Engine linting" contributor section.

# Does this close any currently open issues?

---

- [ ] Unit tests added to cover the fix. *(n/a — config/toolchain change, no `src/**` delta; the CI matrix is the verification)*
- [ ] NUT tests added to cover the fix. *(n/a — same)*
- [ ] E2E tests added to cover the fix. *(n/a — same)*

# Any particular element that can be tested locally

---

- `npm run lint:engine` — exits 0 on a supported node (22.22+/24.15+/26+); exits non-zero if the engines field over-claims the graph or the running node is unsupported.
- `npm run prepublishOnly` — now copies `package-lock.json` → `npm-shrinkwrap.json` (previously `Unknown command: "shrinkwrap"` on npm 12). Delete the generated file afterwards; it is publish-time-only.
- `npm pack --dry-run` — tarball intact; `npm-shrinkwrap.json` absent under npm 12 is expected.

# Any other comments

---

## Provenance & verification

**Design:** `docs/plans/2026-07-15-node-22-engine-upgrade-design.md` (kept out of git per repo policy — carried below).

**Decisions (ADRs 001–008):**
1. `engines.node` = `^22.22 || ^24.15 || >=26` — **user-ratified deviation** from the tool-computed `>= 22.22` (declares exactly the tested lines).
2. Shrinkwrap kept via local copy — **user-ratified deviation** from removal (mechanism preserved if npm re-honours tarball inclusion).
3. Non-matrix CI jobs on `latest` (documented fallback: `lts/*` if a new major outpaces re2 prebuilds).
4. Matrix inside `reusable-build.yml` (single source for PR + main-push).
5. `lint:engine` once per PR, in the npm-lint job (the matrix covers per-line runtime).
6. Plain script, not wireit-wrapped (node-version fingerprint gap).
7. Pre-push `lint:engine` blocking (correctness gate; advisory trio unchanged).
8. Wireit GH cache disabled on matrix legs (per-node execution is the point of the matrix).

**Pinned external behaviour (probed on npm 12.0.1 / node 22.22.3, mktemp throwaways):**
- `npm shrinkwrap` removed (exit 1); `npm-shrinkwrap.json` stripped from tarballs even in `files[]`; `npm ci` still consumes it locally.
- `ls-engines@0.10.1`: too-broad engines field → exit 2; graph-exact or narrower → exit 0 (advisory only); gate driven by running-node validity.
- Graph floor `>= 22.22`; binding constraint `re2@1.26.0`.

**Verification:** commitlint ✓ · `npm outdated` clean ✓ · knip ✓ · `npm audit --audit-level=high` 0 vulns ✓ · `npm pack --dry-run` ✓ · biome ✓ · unit 1574/1574 (100% coverage) ✓ · NUT ✓ · `lint:engine` ✓ · actionlint ✓. Real per-node proof: this PR's CI run must show all three matrix legs executing (not cache-skipping).

**Review:** 4 dimensions (code/security/tests/perf), converged round 1, zero MEDIUM+. Noted LOWs: ls-engines adds ~223 transitive dev packages (accepted trade-off); biome lint re-runs per matrix leg (possible future hoist); shared `~/.npm` download cache across legs is node-agnostic and benign.

**Run record:** workspace reused (prior session) · design self-reviewed ×3 + revised against ADRs · decisions: 3 escalated / 5 adopted-as-recommended · plan 5 parts (plan-lint green) · implementation 5/5 parts, 1 blocker resolved in-session (biome 2.5.4 reformat folded into the bump commit) · GATE(implementation) green · review converged round 1 · auto-skip: refactoring (no src change) · GATE(validation) green · NO-OP(validation:test-mutation) — no mutable src in scope · NO-OP(verify) — no DoD declared; architecture check did not run (phase off).
