### PR TITLE
fix: allowlist re2 install script for npm 12

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install cli
         run: npm install -g @salesforce/cli
 
+      - name: Authorize re2 install script
+        run: npm config set allow-scripts=re2 --location=user
+
       - name: Install new plugin version
         run: echo y | sf plugins install ${{ inputs.channel }}
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ sf plugins install apex-mutation-testing
 sf apex mutation test run --apex-class MyClass --test-class MyClassTest
 ```
 
+**Note**: this plugin depends on [`re2`](https://github.com/google/re2), which builds a native
+binary via an npm install script. On npm 12+, install scripts for dependencies are blocked by
+default, so installing this plugin (`sf plugins install`) may fail to build `re2` and the command
+will error with `MODULE_NOT_FOUND`. If that happens, authorize it before installing:
+
+```sh
+npm config set allow-scripts=re2 --location=user
+```
+
 ## What is it mutation testing ?
 
 Mutation testing is a software testing technique that evaluates the quality of your test suite by introducing small changes (mutations) to your code and checking if your tests can detect these changes. It helps identify weaknesses in your test coverage by measuring how effectively your tests can catch intentional bugs. cf [wikipedia](https://en.wikipedia.org/wiki/Mutation_testing) 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   "overrides": {
     "qs": "^6.15.2"
   },
+  "allowScripts": {
+    "re2": true
+  },
   "engines": {
     "node": "^22.22 || ^24.15 || >=26"
   },


### PR DESCRIPTION
<!-- markdownlint-disable MD025 -->

# Explain your changes

---

## Background

The v1.7.2 release never reached npm: the `publish` job of the NPM Service workflow failed with `MODULE_NOT_FOUND: Cannot find module './build/Release/re2.node'` during `prepack`.

Root cause: **npm 12** (July 2026) blocks dependency lifecycle/install scripts by default unless the install root allowlists them. The publish job runs `npm install -g npm@latest`, so it was the first to hit npm 12.0.1: `npm ci` skipped `re2`'s install script (which downloads/builds the native addon — the tarball ships no binary), and the oclif manifest generation that loads the command graph (`run.ts` → `ConfigReader` → `import RE2 from 're2'`) crashed.

## Fix

- **`package.json`** — add npm 12's `allowScripts` allowlist with a name-only entry `"re2": true`. This authorizes the script for every repo-root install (`npm ci` in CI publish, local dev installs). Name-only rather than version-pinned so the next `re2` bump via `dependencies:upgrade` doesn't silently re-block the script and reintroduce the bug. `fsevents` (transitive, optional, darwin-only, dev-only) is deliberately left blocked — chokidar degrades gracefully.
- **`.github/workflows/run-e2e-tests.yml`** — one step before `sf plugins install`: `npm config set allow-scripts=re2 --location=user`. The e2e job installs the *published* plugin into the sf CLI data dir, a different install root that our committed `allowScripts` does not govern; the user-level npm config is inherited by the oclif-spawned `npm install`.
- **`README.md`** — install note for consumers on npm 12+ with the same workaround, because (verified empirically) a published package's `allowScripts` does **not** authorize its scripts when installed as a dependency — only the install root's config counts.

## Verification

- Clean `npm ci` on npm 12.0.1: no blocked-script warning for `re2`; `node_modules/re2/build/Release/re2.node` present (1.5 MB).
- `npm pack --dry-run` green — exercises the exact `prepublishOnly → prepack → oclif manifest` path that aborted the v1.7.2 publish.
- `npm run test` (build + lint + test:unit + test:nut) green; knip (`lint:dependencies`) does not flag the new field; `actionlint` green on the workflow; commitlint, `npm outdated` (empty), `npm audit` (0 vulns) green.

# Does this close any currently open issues?

---

No open issue — failure observed on the v1.7.2 release run ([failed run](https://github.com/scolladon/apex-mutation-testing/actions/runs/29415778406)).

- [ ] Unit tests added to cover the fix. — N/A: config/CI-only change, no source delta (100% coverage threshold unaffected).
- [ ] NUT tests added to cover the fix. — N/A: same.
- [x] E2E tests added to cover the fix. — the existing e2e workflow now exercises the npm 12 consumer install path with the authorization step; the plugin-install + `--help` smoke is the regression check.

# Any particular element that can be tested locally

---

On npm ≥ 12: `rm -rf node_modules && npm ci` — no `install-scripts` warning naming `re2`, and `ls node_modules/re2/build/Release/re2.node` succeeds. Then `npm pack --dry-run`.

# Any other comments

---

**Consumer impact (honest limitation):** users installing the plugin on npm 12+ still need to authorize `re2` in their own environment (`npm config set allow-scripts=re2 --location=user`) — the README now documents this. The durable fix is making `re2` an optional dependency with a JS regex fallback; tracked as a follow-up.

**Release note:** once merged, v1.7.2 needs re-publishing (the release exists on GitHub but `latest`/`latest-rc` still point at 1.7.1) — either by re-running the release publish or cutting v1.7.3 via release-please.

<details>
<summary>craft run record</summary>

- default-skip: requirements (descriptor enabled:false)
- default-skip: architecture (descriptor enabled:false)
- memory: loaded (14 entries); intention: load no-op (no corpus)
- workspace: worktree + branch fix/allow-re2-install-scripts-npm12, deps installed (re2 script blocked as expected, npm 12.0.1)
- design: docs/plans/allow-re2-install-scripts-npm12.md (uncommitted per repo policy)
- decisions: auto-accepted designer recommendations DC1–DC5 per user instruction (no decision needing user judgment)
- planning: plan (uncommitted); GATE(planning): green (plan-lint 2 parts OK)
- implementation: part 1 `fix: allowlist re2 install script for npm 12` (191018c); part 2 `ci: authorize re2 install script in e2e workflow` (9a8ade2); GATE(implementation): green
- auto-skip: review — evaluated unnecessary (no reviewable source diff; config/CI-only change)
- auto-skip: refactoring — evaluated unnecessary (no source change in scope)
- auto-skip: validation — evaluated unnecessary (no mutable code changed; technique surface empty) — propose gate released
- documentation: README npm-12 note (f231c50); DESIGN.md assessed unaffected
- propose: pre-PR checks green (commitlint, outdated empty, audit 0, pack dry-run, knip, actionlint)

</details>
